### PR TITLE
Add missing City League seasons (3:3-3:6, 3:8) to Pokemon JP API scraper

### DIFF
--- a/config.py
+++ b/config.py
@@ -118,6 +118,19 @@ LIMITLESS_REQUESTS_PER_MINUTE = 25
 LIMITLESS_TIMEOUT = 30.0
 LIMITLESS_MAX_RETRIES = 3
 
+# Pokemon JP API: City League event_type values (3:N = City League Season N)
+# Each season maps to a different competitive period within the championship year.
+POKEMON_JP_CITY_LEAGUE_EVENT_TYPES = [
+    "3:1",
+    "3:2",
+    "3:3",
+    "3:4",
+    "3:5",
+    "3:6",
+    "3:7",
+    "3:8",
+]
+
 # TCGdex
 TCGDEX_API_URL = "https://api.tcgdex.net/v2/en"
 

--- a/scraper/pokemon_jp_api.py
+++ b/scraper/pokemon_jp_api.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 
 import httpx
 
+from config import POKEMON_JP_CITY_LEAGUE_EVENT_TYPES
+
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://players.pokemon-card.com"
@@ -100,7 +102,7 @@ class PokemonJPAPIClient:
                     "offset": offset,
                     "order": 4,  # Sort by date desc
                     "result_resist": 1,  # Only events with results
-                    "event_type[]": ["3:1", "3:2", "3:7"],  # City League types
+                    "event_type[]": POKEMON_JP_CITY_LEAGUE_EVENT_TYPES,
                 },
             )
             resp.raise_for_status()

--- a/tests/test_pokemon_jp_api.py
+++ b/tests/test_pokemon_jp_api.py
@@ -19,6 +19,13 @@ try:
 except ImportError:
     _POKEMON_JP_AVAILABLE = False
 
+try:
+    from scraper.pokemon_jp_api import PokemonJPAPIClient  # noqa: F401
+
+    _POKEMON_JP_API_AVAILABLE = True
+except ImportError:
+    _POKEMON_JP_API_AVAILABLE = False
+
 
 @pytest.mark.skipif(not _POKEMON_JP_AVAILABLE, reason="scraper.pokemon_jp requires 'kernel' module")
 class TestStoreCLResults:
@@ -135,6 +142,29 @@ class TestStoreCLResults:
             (placement2["id"],),
         ).fetchall()
         assert len(cards_for_p2) == 0
+
+
+class TestEventTypeConfig:
+    def test_all_city_league_seasons_included(self):
+        """Ensure all City League seasons 1-8 are included in event types."""
+        from config import POKEMON_JP_CITY_LEAGUE_EVENT_TYPES
+
+        for season in range(1, 9):
+            assert f"3:{season}" in POKEMON_JP_CITY_LEAGUE_EVENT_TYPES, (
+                f"Missing City League season 3:{season}"
+            )
+
+    @pytest.mark.skipif(not _POKEMON_JP_API_AVAILABLE, reason="httpx not installed")
+    def test_scraper_uses_config_event_types(self):
+        """PokemonJPAPIClient should reference config for event types."""
+        import inspect
+
+        from scraper.pokemon_jp_api import PokemonJPAPIClient
+
+        source = inspect.getsource(PokemonJPAPIClient.fetch_cl_events)
+        # Should not have hardcoded event types
+        assert "3:1" not in source, "Event types should come from config, not be hardcoded"
+        assert "POKEMON_JP_CITY_LEAGUE_EVENT_TYPES" in source
 
 
 class TestArchetypeCrossRef:


### PR DESCRIPTION
The scraper was only querying event_type values 3:1, 3:2, and 3:7, missing seasons 3-6 and 8. The event_type parameter format is 3:N where N is the City League season number. Moved the event type list to config.py for centralized management.

https://claude.ai/code/session_01HcpCAA3CNopGP7TJaC58Ub