### PR TITLE
feat: convert guide tool sections to scannable bullet lists

### DIFF
--- a/web/app/guide/__tests__/guide-client.test.tsx
+++ b/web/app/guide/__tests__/guide-client.test.tsx
@@ -59,6 +59,22 @@ describe("GuideClient", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders intro paragraph and bullet items when section is open", () => {
+    render(<GuideClient />);
+    // Dashboard is open by default — check intro and bullets
+    expect(
+      screen.getByText(
+        "Overview of the current meta with tier rankings and card trends."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/ACE SPEC chart shows which ACE SPECs/)
+    ).toBeInTheDocument();
+    // Bullets render as list items
+    const bullets = screen.getAllByRole("listitem");
+    expect(bullets.length).toBeGreaterThanOrEqual(5);
+  });
+
   it("renders the glossary table", () => {
     render(<GuideClient />);
     expect(screen.getByText("Metric Glossary")).toBeInTheDocument();

--- a/web/app/guide/guide-client.tsx
+++ b/web/app/guide/guide-client.tsx
@@ -54,7 +54,7 @@ const TOOL_SECTIONS: {
       "Overview of the current meta with tier rankings and card trends.",
     bullets: [
       "Tiers are based on meta share: S (15%+), A (8-15%), B (3-8%), C (1-3%), Rogue (under 1%)",
-      "Weighted share factors in placement finish (1st = 3.0x, 2nd = 2.5x, 3rd-4th = 2.0x, 5th-8th = 1.5x, 9th-16th = 1.2x, 17th+ = 1.0x) -- decks that consistently finish well rank higher",
+      "Weighted share factors in placement finish (1st = 3.0x, 2nd = 2.5x, 3rd-4th = 2.0x, 5th-8th = 1.5x, 9th-16th = 1.2x, 17th+ = 1.0x), so decks that consistently finish well rank higher",
       "\"Biggest Copy-Count Shifts\" highlights cards whose usage changed the most between the first and second halves of the measured period",
       "\"Winning Edge\" compares card usage in 1st-place decks versus the overall field for S, A, and B tier archetypes",
       "ACE SPEC chart shows which ACE SPECs appear most across top-tier decks",
@@ -274,8 +274,8 @@ export function GuideClient() {
                   <div className="px-4 pb-4 text-surface-300 text-sm font-body leading-relaxed">
                     {section.intro && <p className="mb-2">{section.intro}</p>}
                     <ul className="space-y-1.5 list-disc list-inside marker:text-surface-500">
-                      {section.bullets.map((bullet, i) => (
-                        <li key={i}>{bullet}</li>
+                      {section.bullets.map((bullet) => (
+                        <li key={bullet}>{bullet}</li>
                       ))}
                     </ul>
                   </div>


### PR DESCRIPTION
## Summary
- Replace dense paragraph text in Guide page accordion with intro + bullet-point format for easier scanning
- Add explicit TypeScript type annotation for `TOOL_SECTIONS` array
- All 7 tool sections (Dashboard, Archetypes, Format Edge, Cards, Buy List, Trends, Champions League) updated

## Test plan
- [x] `npm run build` passes with no errors
- [x] All 87 vitest tests pass
- [ ] Visual check: guide page accordion shows intro paragraph + bullet lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)