### PR TITLE
fix: use decklist-only denominator for card inclusion rates

### DIFF
--- a/analysis/buylist.py
+++ b/analysis/buylist.py
@@ -105,10 +105,18 @@ def generate_buylist(conn: sqlite3.Connection, snapshot_id: int) -> list[dict]:
             continue
 
         placement_ids = [p["id"] for p in placements]
-        total_decks = len(placement_ids)
 
         # Step 3: Query decklist_cards for all placements in this archetype
         placeholders = ",".join("?" * len(placement_ids))
+
+        # Only count placements that actually have decklists
+        total_decks = conn.execute(
+            f"SELECT COUNT(DISTINCT placement_id) FROM decklist_cards WHERE placement_id IN ({placeholders})",
+            placement_ids,
+        ).fetchone()[0]
+
+        if total_decks == 0:
+            continue
         energy_placeholders = ",".join("?" * len(BASIC_ENERGY_NAMES))
         decklist_rows = conn.execute(
             f"""

--- a/analysis/card_stats.py
+++ b/analysis/card_stats.py
@@ -195,7 +195,10 @@ def compute_card_stats(conn: sqlite3.Connection) -> list[dict]:
 
     Returns a list of card stat dicts, sorted by total_appearances descending.
     """
-    total_decks = conn.execute("SELECT COUNT(*) FROM open_placements").fetchone()[0]
+    # Only count open-division placements that actually have decklists
+    total_decks = conn.execute(
+        "SELECT COUNT(DISTINCT dc.placement_id) FROM decklist_cards dc JOIN open_placements p ON p.id = dc.placement_id"
+    ).fetchone()[0]
     if total_decks == 0:
         return []
 
@@ -304,7 +307,10 @@ def compute_card_detail(conn: sqlite3.Connection, card_name: str) -> dict | None
     """Compute detailed stats for a single card including archetype breakdown,
     weekly usage, and copy distribution.
     """
-    total_decks = conn.execute("SELECT COUNT(*) FROM open_placements").fetchone()[0]
+    # Only count open-division placements that actually have decklists
+    total_decks = conn.execute(
+        "SELECT COUNT(DISTINCT dc.placement_id) FROM decklist_cards dc JOIN open_placements p ON p.id = dc.placement_id"
+    ).fetchone()[0]
     if total_decks == 0:
         return None
 
@@ -428,11 +434,12 @@ def compute_card_detail(conn: sqlite3.Connection, card_name: str) -> dict | None
     week_card_appearances: dict[str, int] = defaultdict(int)
     week_card_copies: dict[str, int] = defaultdict(int)
 
-    # Get all placements per week for denominator
+    # Get all placements with decklists per week for denominator
     all_placements = conn.execute(
         """
         SELECT t.date FROM open_placements p
         JOIN tournaments t ON t.id = p.tournament_id
+        WHERE p.id IN (SELECT DISTINCT placement_id FROM decklist_cards)
         ORDER BY t.date
         """
     ).fetchall()

--- a/analysis/deep_dive.py
+++ b/analysis/deep_dive.py
@@ -36,12 +36,29 @@ def compute_weighted_consensus_60(
         return None
 
     placement_ids = [r["placement_id"] for r in rows]
-    weight_by_pid = {r["placement_id"]: _get_placement_weight(r["standing"]) for r in rows}
-    total_weight = sum(weight_by_pid.values())
 
     energy_names = sorted(BASIC_ENERGY_NAMES)
     energy_placeholders = ",".join("?" * len(energy_names))
     pid_placeholders = ",".join("?" * len(placement_ids))
+
+    # Only consider placements that actually have decklists
+    pids_with_decklists = {
+        r[0]
+        for r in conn.execute(
+            f"SELECT DISTINCT placement_id FROM decklist_cards WHERE placement_id IN ({pid_placeholders})",
+            placement_ids,
+        ).fetchall()
+    }
+
+    if len(pids_with_decklists) < 3:
+        return None
+
+    weight_by_pid = {
+        r["placement_id"]: _get_placement_weight(r["standing"])
+        for r in rows
+        if r["placement_id"] in pids_with_decklists
+    }
+    total_weight = sum(weight_by_pid.values())
 
     card_rows = conn.execute(
         f"""
@@ -61,14 +78,16 @@ def compute_weighted_consensus_60(
         lambda: {"weighted_sum": 0.0, "weighted_copies": 0.0, "raw_count": 0, "total_copies": 0}
     )
     for cr in card_rows:
-        w = weight_by_pid[cr["placement_id"]]
+        w = weight_by_pid.get(cr["placement_id"])
+        if w is None:
+            continue
         cd = card_data[cr["card_name"]]
         cd["weighted_sum"] += w
         cd["weighted_copies"] += cr["count"] * w
         cd["raw_count"] += 1
         cd["total_copies"] += cr["count"]
 
-    total_decks = len(placement_ids)
+    total_decks = len(pids_with_decklists)
     cards = []
     for card_name, cd in card_data.items():
         weighted_inclusion = round(cd["weighted_sum"] / total_weight * 100, 1)
@@ -174,8 +193,17 @@ def compute_weekly_card_timeline(
     week_card_data: dict[str, dict[str, dict]] = {}
     for wk in weeks:
         pids = week_pids[wk]
-        total = len(pids)
         placeholders = ",".join("?" * len(pids))
+
+        # Only count placements that actually have decklists
+        total = conn.execute(
+            f"SELECT COUNT(DISTINCT placement_id) FROM decklist_cards WHERE placement_id IN ({placeholders})",
+            pids,
+        ).fetchone()[0]
+
+        if total == 0:
+            continue
+
         card_rows = conn.execute(
             f"""
             SELECT dc.card_name,

--- a/analysis/evolution.py
+++ b/analysis/evolution.py
@@ -61,12 +61,17 @@ def compute_archetype_evolution(
 
     for wk in weeks:
         pids = week_placements[wk]
-        total = len(pids)
+        placeholders = ",".join("?" * len(pids))
+
+        # Only count placements that actually have decklists
+        total = conn.execute(
+            f"SELECT COUNT(DISTINCT placement_id) FROM decklist_cards WHERE placement_id IN ({placeholders})",
+            pids,
+        ).fetchone()[0]
+
         if total == 0:
-            week_card_rates[wk] = {}
             continue
 
-        placeholders = ",".join("?" * len(pids))
         card_rows = conn.execute(
             f"""
             SELECT dc.card_name, COUNT(DISTINCT dc.placement_id) AS cnt
@@ -83,11 +88,15 @@ def compute_archetype_evolution(
             rates[cr["card_name"]] = round(cr["cnt"] / total * 100, 1)
         week_card_rates[wk] = rates
 
-    # Detect adoption/drop events between consecutive weeks
+    # Detect adoption/drop events between consecutive weeks with data
+    weeks_with_data = [wk for wk in weeks if wk in week_card_rates]
+    if len(weeks_with_data) < 2:
+        return []
+
     evolution = []
-    for i in range(1, len(weeks)):
-        prev_week = weeks[i - 1]
-        curr_week = weeks[i]
+    for i in range(1, len(weeks_with_data)):
+        prev_week = weeks_with_data[i - 1]
+        curr_week = weeks_with_data[i]
         prev_rates = week_card_rates[prev_week]
         curr_rates = week_card_rates[curr_week]
 

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -79,3 +79,100 @@ class TestComputeMetaEvolution:
         result = compute_meta_evolution(db)
         for i in range(len(result) - 1):
             assert result[i]["week"] >= result[i + 1]["week"]
+
+
+class TestDecklistDenominator:
+    """Inclusion rates should only count placements that have decklists."""
+
+    def test_placements_without_decklists_excluded_from_denominator(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(SCHEMA)
+
+        # Two weeks of tournaments
+        conn.executemany(
+            "INSERT INTO tournaments (id, name, date, player_count) VALUES (?, ?, ?, ?)",
+            [
+                ("t1", "Week 1", "2026-01-20", 64),
+                ("t2", "Week 2", "2026-01-27", 64),
+            ],
+        )
+
+        # Week 1: 1 placement WITH decklist containing Night Stretcher
+        # Week 2: 3 placements but only 1 has a decklist (also with Night Stretcher)
+        conn.executemany(
+            "INSERT INTO placements (id, tournament_id, standing, player_name, archetype) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (1, "t1", 1, "Alice", "Mega Lucario"),
+                (2, "t2", 1, "Bob", "Mega Lucario"),
+                (3, "t2", 2, "Charlie", "Mega Lucario"),  # no decklist
+                (4, "t2", 3, "Diana", "Mega Lucario"),  # no decklist
+            ],
+        )
+
+        # Decklists: only placements 1 and 2 have decklist data
+        conn.executemany(
+            "INSERT INTO decklist_cards (placement_id, card_id, card_name, count) VALUES (?, ?, ?, ?)",
+            [
+                (1, "card-ns", "Night Stretcher", 2),
+                (1, "card-ub", "Ultra Ball", 4),
+                (2, "card-ns", "Night Stretcher", 2),
+                (2, "card-ub", "Ultra Ball", 4),
+            ],
+        )
+        conn.commit()
+
+        result = compute_archetype_evolution(conn, "Mega Lucario")
+
+        # Night Stretcher is at 100% both weeks (1/1 and 1/1 decklist placements).
+        # Without the fix, week 2 would show 1/3 = 33%, triggering a false "drop".
+        # With the fix, no drop events should be reported for Night Stretcher.
+        for event in result:
+            dropped_cards = [c["card"] for c in event["dropped"]]
+            assert "Night Stretcher" not in dropped_cards, (
+                f"Night Stretcher falsely reported as dropped: {event}"
+            )
+
+        conn.close()
+
+    def test_week_with_no_decklists_skipped(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(SCHEMA)
+
+        conn.executemany(
+            "INSERT INTO tournaments (id, name, date, player_count) VALUES (?, ?, ?, ?)",
+            [
+                ("t1", "Week 1", "2026-01-20", 64),
+                ("t2", "Week 2", "2026-01-27", 64),
+            ],
+        )
+
+        # Week 1: placement with decklist; Week 2: placement without decklist
+        conn.executemany(
+            "INSERT INTO placements (id, tournament_id, standing, player_name, archetype) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (1, "t1", 1, "Alice", "Test Deck"),
+                (2, "t2", 1, "Bob", "Test Deck"),  # no decklist
+            ],
+        )
+
+        conn.executemany(
+            "INSERT INTO decklist_cards (placement_id, card_id, card_name, count) VALUES (?, ?, ?, ?)",
+            [
+                (1, "card-ns", "Night Stretcher", 2),
+            ],
+        )
+        conn.commit()
+
+        result = compute_archetype_evolution(conn, "Test Deck")
+
+        # Week 2 has no decklists, so no comparison should happen.
+        # Without the fix, Night Stretcher would show 100% -> 0% (false drop).
+        for event in result:
+            dropped_cards = [c["card"] for c in event["dropped"]]
+            assert "Night Stretcher" not in dropped_cards
+
+        conn.close()


### PR DESCRIPTION
## Summary

- Placements without scraped decklists were counted in the denominator for card inclusion percentages, causing staple cards to appear as dropped (e.g. Night Stretcher 96% → 0% in Mega Lucario)
- Fixed all 4 affected analysis modules (`evolution.py`, `deep_dive.py`, `buylist.py`, `card_stats.py`) to only count placements with `decklist_cards` rows in the denominator
- Weeks without any decklists are now skipped in evolution comparisons instead of showing 0% for all cards

## Test plan

- [x] Added 2 regression tests in `test_evolution.py` reproducing the Night Stretcher false-drop scenario
- [x] All 305 Python tests pass
- [x] All 88 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)