### PR TITLE
feat: add dedicated copy-count shifts page with filters

### DIFF
--- a/analysis/evolution.py
+++ b/analysis/evolution.py
@@ -4,7 +4,7 @@ import sqlite3
 from collections import defaultdict
 from datetime import date, timedelta
 
-from analysis.card_stats import BASIC_ENERGY_NAMES
+from analysis.card_stats import BASIC_ENERGY_NAMES, _slugify
 
 
 def compute_archetype_evolution(
@@ -145,26 +145,22 @@ def compute_archetype_evolution(
     return evolution
 
 
-def compute_meta_evolution(conn: sqlite3.Connection, top_n: int = 5) -> list[dict]:
-    """Compute format-wide "what changed this week" — top card movements across all archetypes.
+def compute_meta_evolution(conn: sqlite3.Connection, top_n: int | None = None) -> dict:
+    """Compute format-wide "what changed this week" — card movements across all archetypes.
 
-    Returns a list of the most significant card movements:
-    [
-        {
-            "card": "Card Name",
-            "archetype": "Archetype Name",
-            "direction": "adopted" | "dropped",
-            "from_pct": 15.0,
-            "to_pct": 55.0,
-            "week": "2026-03-03",
-        },
-        ...
-    ]
+    Returns a dict with highlights (top 5) and all movements:
+    {
+        "highlights": [...top 5 movements...],
+        "movements": [...all movements...],
+    }
+
+    Each movement has: card, archetype, archetype_slug, direction, from_pct,
+    to_pct, delta, deck_count, week.
     """
     # Get all archetypes from latest snapshot
     arch_rows = conn.execute(
         """
-        SELECT archetype FROM archetype_stats
+        SELECT archetype, deck_count FROM archetype_stats
         WHERE snapshot_id = (SELECT MAX(id) FROM meta_snapshots)
           AND tier IN ('S', 'A', 'B')
         ORDER BY deck_count DESC
@@ -172,38 +168,46 @@ def compute_meta_evolution(conn: sqlite3.Connection, top_n: int = 5) -> list[dic
     ).fetchall()
 
     if not arch_rows:
-        return []
+        return {"highlights": [], "movements": []}
 
     all_movements = []
     for ar in arch_rows:
         evolution = compute_archetype_evolution(conn, ar["archetype"])
         for event in evolution:
+            base = {
+                "archetype": ar["archetype"],
+                "archetype_slug": _slugify(ar["archetype"]),
+                "deck_count": ar["deck_count"],
+                "week": event["week"],
+            }
             for card in event["adopted"]:
                 all_movements.append(
                     {
+                        **base,
                         "card": card["card"],
-                        "archetype": ar["archetype"],
                         "direction": "adopted",
                         "from_pct": card["from_pct"],
                         "to_pct": card["to_pct"],
                         "delta": round(card["to_pct"] - card["from_pct"], 1),
-                        "week": event["week"],
                     }
                 )
             for card in event["dropped"]:
                 all_movements.append(
                     {
+                        **base,
                         "card": card["card"],
-                        "archetype": ar["archetype"],
                         "direction": "dropped",
                         "from_pct": card["from_pct"],
                         "to_pct": card["to_pct"],
                         "delta": round(card["from_pct"] - card["to_pct"], 1),
-                        "week": event["week"],
                     }
                 )
 
     # Sort by recency then magnitude
     all_movements.sort(key=lambda m: (m["week"], m["delta"]), reverse=True)
 
-    return all_movements[:top_n]
+    limit = top_n if top_n is not None else 5
+    return {
+        "highlights": all_movements[:limit],
+        "movements": all_movements,
+    }

--- a/reports/json_export.py
+++ b/reports/json_export.py
@@ -2405,10 +2405,14 @@ def export_cards(conn: sqlite3.Connection, output_dir: Path) -> None:
 
 
 def export_meta_evolution(conn: sqlite3.Connection, output_dir: Path) -> None:
-    """Export format-wide meta evolution — top card movements across all archetypes."""
-    movements = compute_meta_evolution(conn)
-    _write_json(movements, output_dir / "meta-evolution.json")
-    logger.info("Exported %d meta evolution movements", len(movements))
+    """Export format-wide meta evolution — highlights + all movements."""
+    data = compute_meta_evolution(conn)
+    _write_json(data, output_dir / "meta-evolution.json")
+    logger.info(
+        "Exported meta evolution (%d highlights, %d total movements)",
+        len(data["highlights"]),
+        len(data["movements"]),
+    )
 
 
 def export_matchup_matrix(conn: sqlite3.Connection, output_dir: Path) -> None:

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -56,29 +56,47 @@ class TestComputeArchetypeEvolution:
 
 
 class TestComputeMetaEvolution:
-    def test_returns_list(self, db):
+    def test_returns_dict_with_highlights_and_movements(self, db):
         result = compute_meta_evolution(db)
-        assert isinstance(result, list)
+        assert isinstance(result, dict)
+        assert "highlights" in result
+        assert "movements" in result
+        assert isinstance(result["highlights"], list)
+        assert isinstance(result["movements"], list)
 
     def test_movement_structure(self, db):
         result = compute_meta_evolution(db)
-        for m in result:
+        for m in result["movements"]:
             assert "card" in m
             assert "archetype" in m
+            assert "archetype_slug" in m
+            # Slug must be lowercase with no spaces
+            assert m["archetype_slug"] == m["archetype_slug"].lower()
+            assert " " not in m["archetype_slug"]
+            assert "deck_count" in m
+            assert isinstance(m["deck_count"], int)
             assert "direction" in m
             assert m["direction"] in ("adopted", "dropped")
             assert "from_pct" in m
             assert "to_pct" in m
+            assert "delta" in m
             assert "week" in m
 
     def test_limited_to_top_n(self, db):
         result = compute_meta_evolution(db, top_n=3)
-        assert len(result) <= 3
+        assert len(result["highlights"]) <= 3
+
+    def test_highlights_subset_of_movements(self, db):
+        result = compute_meta_evolution(db)
+        assert len(result["highlights"]) <= len(result["movements"])
+        for h in result["highlights"]:
+            assert h in result["movements"]
 
     def test_sorted_by_recency(self, db):
         result = compute_meta_evolution(db)
-        for i in range(len(result) - 1):
-            assert result[i]["week"] >= result[i + 1]["week"]
+        movements = result["movements"]
+        for i in range(len(movements) - 1):
+            assert movements[i]["week"] >= movements[i + 1]["week"]
 
 
 class TestDecklistDenominator:

--- a/tests/test_json_export.py
+++ b/tests/test_json_export.py
@@ -485,14 +485,18 @@ class TestExportMetaEvolution:
         out_file = tmp_path / "meta-evolution.json"
         assert out_file.exists()
         data = json.loads(out_file.read_text())
-        assert isinstance(data, list)
+        assert isinstance(data, dict)
+        assert "highlights" in data
+        assert "movements" in data
 
     def test_movements_have_required_fields(self, db, tmp_path):
         export_meta_evolution(db, tmp_path)
         data = json.loads((tmp_path / "meta-evolution.json").read_text())
-        for m in data:
+        for m in data["movements"]:
             assert "card" in m
             assert "archetype" in m
+            assert "archetype_slug" in m
+            assert "deck_count" in m
             assert "direction" in m
             assert m["direction"] in ("adopted", "dropped")
 

--- a/web/app/[format]/dashboard-client.tsx
+++ b/web/app/[format]/dashboard-client.tsx
@@ -267,6 +267,12 @@ export function DashboardClient({
                   <Zap className="w-4 h-4 text-amber-400" />
                   Biggest Copy-Count Shifts
                 </h3>
+                <Link
+                  href={`/${format}/shifts`}
+                  className="text-xs text-amber-400 hover:text-amber-300 flex items-center gap-1"
+                >
+                  View all <ArrowRight className="w-3 h-3" />
+                </Link>
               </div>
               <div className="space-y-3">
                 {metaEvolution.map((m, i) => (

--- a/web/app/[format]/page.tsx
+++ b/web/app/[format]/page.tsx
@@ -40,7 +40,7 @@ export default async function Dashboard({
       winningEdge={winningEdge}
       aceSpecs={aceSpecs}
       timeline={timeline}
-      metaEvolution={metaEvolution}
+      metaEvolution={metaEvolution.highlights}
     />
   );
 }

--- a/web/app/[format]/shifts/__tests__/shifts-client.test.tsx
+++ b/web/app/[format]/shifts/__tests__/shifts-client.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ShiftsClient } from "../shifts-client";
+import type { MetaEvolutionMovement } from "@/app/lib/types";
+
+const mockMovements: MetaEvolutionMovement[] = [
+  {
+    card: "Night Stretcher",
+    archetype: "Mega Lucario",
+    archetype_slug: "mega-lucario",
+    deck_count: 42,
+    direction: "dropped",
+    from_pct: 96,
+    to_pct: 0,
+    delta: 96,
+    week: "2026-03-16",
+  },
+  {
+    card: "Briar",
+    archetype: "Dragapult Dusknoir",
+    archetype_slug: "dragapult-dusknoir",
+    deck_count: 30,
+    direction: "adopted",
+    from_pct: 26,
+    to_pct: 50,
+    delta: 24,
+    week: "2026-03-16",
+  },
+  {
+    card: "Meowth ex",
+    archetype: "Dragapult Meowth",
+    archetype_slug: "dragapult-meowth",
+    deck_count: 15,
+    direction: "dropped",
+    from_pct: 50,
+    to_pct: 18,
+    delta: 32,
+    week: "2026-03-09",
+  },
+];
+
+describe("ShiftsClient", () => {
+  afterEach(cleanup);
+
+  it("renders all movements", () => {
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    expect(screen.getByText("Night Stretcher")).toBeInTheDocument();
+    expect(screen.getByText("Briar")).toBeInTheDocument();
+    expect(screen.getByText("Meowth ex")).toBeInTheDocument();
+  });
+
+  it("renders page title", () => {
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    expect(screen.getByText("Copy-Count Shifts")).toBeInTheDocument();
+  });
+
+  it("shows correct count", () => {
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    expect(screen.getByText("3 shifts")).toBeInTheDocument();
+  });
+
+  it("filters by direction - Drops only", async () => {
+    const user = userEvent.setup();
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    await user.click(screen.getByRole("button", { name: "Drops" }));
+    expect(screen.getByText("Night Stretcher")).toBeInTheDocument();
+    expect(screen.getByText("Meowth ex")).toBeInTheDocument();
+    expect(screen.queryByText("Briar")).not.toBeInTheDocument();
+    expect(screen.getByText("2 shifts")).toBeInTheDocument();
+  });
+
+  it("filters by direction - Rises only", async () => {
+    const user = userEvent.setup();
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    await user.click(screen.getByRole("button", { name: "Rises" }));
+    expect(screen.getByText("Briar")).toBeInTheDocument();
+    expect(screen.queryByText("Night Stretcher")).not.toBeInTheDocument();
+    expect(screen.getByText("1 shift")).toBeInTheDocument();
+  });
+
+  it("renders archetype links", () => {
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    const link = screen.getByRole("link", { name: "Mega Lucario" });
+    expect(link).toHaveAttribute("href", "/ninja-spinner/archetypes/mega-lucario");
+  });
+
+  it("renders empty state when no movements", () => {
+    render(<ShiftsClient format="ninja-spinner" movements={[]} />);
+    expect(screen.getByText("No significant copy-count shifts detected yet.")).toBeInTheDocument();
+  });
+
+  it("renders deck count for movements with data", () => {
+    render(<ShiftsClient format="ninja-spinner" movements={mockMovements} />);
+    expect(screen.getByText("(42 decks)")).toBeInTheDocument();
+  });
+});

--- a/web/app/[format]/shifts/page.tsx
+++ b/web/app/[format]/shifts/page.tsx
@@ -1,0 +1,23 @@
+import { getMetaEvolution, formatHasData } from "@/app/lib/data";
+import { ShiftsClient } from "./shifts-client";
+import Link from "next/link";
+
+export default async function ShiftsPage({
+  params,
+}: {
+  params: Promise<{ format: string }>;
+}) {
+  const { format } = await params;
+
+  if (!formatHasData(format)) {
+    return (
+      <div className="text-center py-24">
+        <p className="text-surface-300">No data available yet for this format.</p>
+        <Link href="/" className="mt-4 inline-block text-sm text-accent">Back to formats</Link>
+      </div>
+    );
+  }
+
+  const metaEvolution = getMetaEvolution(format);
+  return <ShiftsClient format={format} movements={metaEvolution.movements} />;
+}

--- a/web/app/[format]/shifts/shifts-client.tsx
+++ b/web/app/[format]/shifts/shifts-client.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { ArrowLeft, TrendingUp, TrendingDown, Zap } from "lucide-react";
+import type { MetaEvolutionMovement } from "@/app/lib/types";
+
+type DirectionFilter = "all" | "adopted" | "dropped";
+type SortMode = "magnitude" | "recency";
+
+interface ShiftsClientProps {
+  format: string;
+  movements: MetaEvolutionMovement[];
+}
+
+export function ShiftsClient({ format, movements }: ShiftsClientProps) {
+  const [directionFilter, setDirectionFilter] = useState<DirectionFilter>("all");
+  const [archetypeFilter, setArchetypeFilter] = useState<string>("all");
+  const [sortMode, setSortMode] = useState<SortMode>("magnitude");
+
+  const archetypes = useMemo(() => {
+    const unique = [...new Set(movements.map((m) => m.archetype))];
+    return unique.sort();
+  }, [movements]);
+
+  const maxDelta = useMemo(
+    () => Math.max(...movements.map((m) => m.delta), 1),
+    [movements]
+  );
+
+  const latestWeek = useMemo(() => {
+    if (movements.length === 0) return null;
+    return movements[0].week;
+  }, [movements]);
+
+  const filtered = useMemo(() => {
+    let result = movements;
+
+    if (directionFilter !== "all") {
+      result = result.filter((m) => m.direction === directionFilter);
+    }
+
+    if (archetypeFilter !== "all") {
+      result = result.filter((m) => m.archetype === archetypeFilter);
+    }
+
+    if (sortMode === "magnitude") {
+      result = [...result].sort((a, b) => b.delta - a.delta);
+    }
+    // recency is the default sort from backend (week DESC, delta DESC)
+
+    return result;
+  }, [movements, directionFilter, archetypeFilter, sortMode]);
+
+  const formatWeek = (iso: string) => {
+    const d = new Date(iso + "T00:00:00");
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  };
+
+  if (movements.length === 0) {
+    return (
+      <div className="text-center py-24">
+        <Zap className="w-8 h-8 text-surface-400 mx-auto mb-4" />
+        <p className="text-surface-300">No significant copy-count shifts detected yet.</p>
+        <Link href={`/${format}`} className="mt-4 inline-block text-sm text-amber-400 hover:text-amber-300">
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <Link
+          href={`/${format}`}
+          className="inline-flex items-center gap-1 text-xs text-surface-300 hover:text-slate-200 mb-3"
+        >
+          <ArrowLeft className="w-3 h-3" />
+          Dashboard
+        </Link>
+        <div className="flex items-center justify-between">
+          <h1 className="font-display text-2xl font-bold text-slate-100 flex items-center gap-3">
+            <Zap className="w-6 h-6 text-amber-400" />
+            Copy-Count Shifts
+          </h1>
+          {latestWeek && (
+            <span className="text-xs text-surface-300">
+              Latest: week of {formatWeek(latestWeek)}
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-surface-300 mt-1">
+          Cards crossing adoption or drop thresholds across top-tier archetypes
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Direction filter */}
+        <div className="inline-flex rounded-lg border border-surface-600 overflow-hidden">
+          {(["all", "adopted", "dropped"] as DirectionFilter[]).map((dir) => (
+            <button
+              key={dir}
+              onClick={() => setDirectionFilter(dir)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                directionFilter === dir
+                  ? "bg-surface-600 text-slate-100"
+                  : "bg-surface-800 text-surface-300 hover:text-slate-200 hover:bg-surface-700"
+              }`}
+            >
+              {dir === "all" ? "All" : dir === "adopted" ? "Rises" : "Drops"}
+            </button>
+          ))}
+        </div>
+
+        {/* Archetype filter */}
+        <select
+          value={archetypeFilter}
+          onChange={(e) => setArchetypeFilter(e.target.value)}
+          className="bg-surface-800 border border-surface-600 text-sm text-slate-300 rounded-lg px-3 py-1.5 focus:outline-none focus:border-surface-400"
+        >
+          <option value="all">All archetypes</option>
+          {archetypes.map((a) => (
+            <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+
+        {/* Sort toggle */}
+        <div className="inline-flex rounded-lg border border-surface-600 overflow-hidden">
+          {(["magnitude", "recency"] as SortMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setSortMode(mode)}
+              className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                sortMode === mode
+                  ? "bg-surface-600 text-slate-100"
+                  : "bg-surface-800 text-surface-300 hover:text-slate-200 hover:bg-surface-700"
+              }`}
+            >
+              {mode === "magnitude" ? "By magnitude" : "By recency"}
+            </button>
+          ))}
+        </div>
+
+        <span className="text-xs text-surface-400 ml-auto">
+          {filtered.length} shift{filtered.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Results */}
+      <div className="space-y-2">
+        {filtered.map((m, i) => {
+          const barWidth = (m.delta / maxDelta) * 100;
+          const isHigh = m.delta >= 30;
+          const isMedium = m.delta >= 10 && m.delta < 30;
+
+          return (
+            <div
+              key={`${m.card}-${m.archetype}-${m.week}-${i}`}
+              className="relative bg-surface-800 border border-surface-600 rounded-lg p-4 overflow-hidden"
+            >
+              {/* Magnitude bar background */}
+              <div
+                className={`absolute inset-y-0 left-0 ${
+                  m.direction === "adopted" ? "bg-emerald-500/8" : "bg-red-500/8"
+                }`}
+                style={{ width: `${barWidth}%` }}
+              />
+
+              <div className="relative flex items-center justify-between gap-4">
+                {/* Left side: icon + card info */}
+                <div className="flex items-center gap-3 min-w-0">
+                  {m.direction === "adopted" ? (
+                    <TrendingUp
+                      className={`w-4 h-4 shrink-0 ${
+                        isHigh ? "text-emerald-400" : isMedium ? "text-emerald-400/70" : "text-surface-400"
+                      }`}
+                    />
+                  ) : (
+                    <TrendingDown
+                      className={`w-4 h-4 shrink-0 ${
+                        isHigh ? "text-red-400" : isMedium ? "text-red-400/70" : "text-surface-400"
+                      }`}
+                    />
+                  )}
+                  <div className="min-w-0">
+                    <span
+                      className={`text-sm truncate block ${
+                        isHigh ? "font-semibold text-slate-100" : isMedium ? "text-slate-200" : "text-surface-300"
+                      }`}
+                    >
+                      {m.card}
+                    </span>
+                    <span className="text-[11px] text-surface-400 flex items-center gap-1.5">
+                      in{" "}
+                      {m.archetype_slug ? (
+                        <Link
+                          href={`/${format}/archetypes/${m.archetype_slug}`}
+                          className="text-surface-300 hover:text-slate-200 underline decoration-surface-600 underline-offset-2"
+                        >
+                          {m.archetype}
+                        </Link>
+                      ) : (
+                        m.archetype
+                      )}
+                      {m.deck_count != null && (
+                        <span className="text-surface-400">({m.deck_count} decks)</span>
+                      )}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Right side: percentages */}
+                <div className="flex items-center gap-3 shrink-0">
+                  <span
+                    className={`font-mono text-xs whitespace-nowrap ${
+                      isHigh ? "text-slate-200" : "text-surface-300"
+                    }`}
+                  >
+                    {m.from_pct.toFixed(0)}% &rarr; {m.to_pct.toFixed(0)}%
+                  </span>
+                  <span
+                    className={`font-mono text-xs font-medium px-1.5 py-0.5 rounded ${
+                      m.direction === "adopted"
+                        ? isHigh
+                          ? "text-emerald-400 bg-emerald-500/15"
+                          : "text-emerald-400/70 bg-emerald-500/8"
+                        : isHigh
+                          ? "text-red-400 bg-red-500/15"
+                          : "text-red-400/70 bg-red-500/8"
+                    }`}
+                  >
+                    {m.direction === "adopted" ? "+" : "-"}{m.delta.toFixed(0)}pp
+                  </span>
+                </div>
+              </div>
+
+              {/* Week label for non-latest weeks */}
+              {m.week !== latestWeek && (
+                <span className="absolute top-1.5 right-2 text-[10px] text-surface-400">
+                  {formatWeek(m.week)}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-surface-300 text-sm">No shifts match the current filters.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/components/nav.tsx
+++ b/web/app/components/nav.tsx
@@ -140,6 +140,7 @@ export function Nav({ format, formats }: { format: string; formats: FormatInfo[]
       label: "Meta",
       items: [
         { href: `/${format}/trends`, label: "Trends" },
+        { href: `/${format}/shifts`, label: "Shifts" },
         { href: `/${format}/forecast`, label: "Forecast" },
       ],
     },

--- a/web/app/lib/__tests__/data.test.ts
+++ b/web/app/lib/__tests__/data.test.ts
@@ -12,7 +12,7 @@ vi.mock("fs", () => ({
 }));
 
 import fs from "fs";
-import { getMeta, getTrends, getArchetypeSlugs, getFormats, getCardAnalysis, getTechForecast, getMetaReport } from "../data";
+import { getMeta, getTrends, getArchetypeSlugs, getFormats, getCardAnalysis, getTechForecast, getMetaReport, getMetaEvolution } from "../data";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -249,5 +249,47 @@ describe("getMetaReport", () => {
   it("returns null when report file has invalid JSON", () => {
     vi.mocked(fs.readFileSync).mockReturnValue("not valid json{{{");
     expect(getMetaReport("nihil-zero")).toBeNull();
+  });
+});
+
+describe("getMetaEvolution", () => {
+  it("returns new object format as-is", () => {
+    const mockData = {
+      highlights: [{ card: "Iono", archetype: "Charizard", direction: "adopted", from_pct: 10, to_pct: 60, delta: 50, week: "2026-03-16" }],
+      movements: [
+        { card: "Iono", archetype: "Charizard", direction: "adopted", from_pct: 10, to_pct: 60, delta: 50, week: "2026-03-16" },
+        { card: "Arven", archetype: "Charizard", direction: "dropped", from_pct: 80, to_pct: 10, delta: 70, week: "2026-03-16" },
+      ],
+    };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockData));
+    const result = getMetaEvolution("ninja-spinner");
+    expect(result.highlights).toHaveLength(1);
+    expect(result.movements).toHaveLength(2);
+  });
+
+  it("wraps legacy bare-array format", () => {
+    const mockArray = [
+      { card: "Iono", archetype: "Charizard", direction: "adopted", from_pct: 10, to_pct: 60, delta: 50, week: "2026-03-16" },
+    ];
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockArray));
+    const result = getMetaEvolution("ninja-spinner");
+    expect(result.highlights).toEqual(mockArray);
+    expect(result.movements).toEqual(mockArray);
+  });
+
+  it("returns empty when file not found", () => {
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    });
+    const result = getMetaEvolution("ninja-spinner");
+    expect(result.highlights).toEqual([]);
+    expect(result.movements).toEqual([]);
+  });
+
+  it("throws on non-ENOENT errors", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("not valid json{{{");
+    expect(() => getMetaEvolution("ninja-spinner")).toThrow();
   });
 });

--- a/web/app/lib/data.ts
+++ b/web/app/lib/data.ts
@@ -16,6 +16,7 @@ import type {
   CardDetail,
   SynergyPair,
   MetaEvolutionMovement,
+  MetaEvolutionData,
   MatchupMatrixData,
   OverlapMatrixData,
   CardAnalysisData,
@@ -137,13 +138,23 @@ export function getCardSlugs(format: string): string[] {
     .map((f) => f.replace(".json", ""));
 }
 
-export function getMetaEvolution(format: string): MetaEvolutionMovement[] {
+export function getMetaEvolution(format: string): MetaEvolutionData {
+  const empty: MetaEvolutionData = { highlights: [], movements: [] };
   try {
-    return readJson(`${format}/meta-evolution.json`);
+    const raw = readJson<MetaEvolutionData | MetaEvolutionMovement[]>(
+      `${format}/meta-evolution.json`
+    );
+    // Support both old (bare array) and new (object) formats
+    if (Array.isArray(raw)) {
+      console.warn(
+        `[data] meta-evolution.json for "${format}" uses legacy array format`
+      );
+      return { highlights: raw, movements: raw };
+    }
+    return raw;
   } catch (err) {
-    if (isFileNotFound(err)) return [];
-    console.error(`Failed to load meta evolution for ${format}:`, err);
-    return [];
+    if (isFileNotFound(err)) return empty;
+    throw err;
   }
 }
 

--- a/web/app/lib/types.ts
+++ b/web/app/lib/types.ts
@@ -273,11 +273,25 @@ export interface EvolutionEvent {
 export interface MetaEvolutionMovement {
   card: string;
   archetype: string;
+  /** Always present in exports after 2026-03-21; absent in legacy bare-array format. */
+  archetype_slug?: string;
+  /** Always present in exports after 2026-03-21; absent in legacy bare-array format. */
+  deck_count?: number;
   direction: "adopted" | "dropped";
   from_pct: number;
   to_pct: number;
   delta: number;
   week: string;
+}
+
+/**
+ * Format-wide card adoption/drop movements.
+ * `highlights` is the top 5 movements by recency+magnitude (subset of `movements`).
+ * `movements` is the complete list, sorted by week DESC then delta DESC.
+ */
+export interface MetaEvolutionData {
+  highlights: MetaEvolutionMovement[];
+  movements: MetaEvolutionMovement[];
 }
 
 export interface OverlapMatrixData {


### PR DESCRIPTION
## Summary

- Expands the dashboard's top-5 "Biggest Copy-Count Shifts" into a dedicated page at `/{format}/shifts`
- Backend exports all movements (not capped at 5) with new `archetype_slug` and `deck_count` fields
- JSON restructured from bare array to `{ highlights, movements }` with backward compat for legacy format
- Page includes direction filter (All/Rises/Drops), archetype dropdown, magnitude sort toggle
- Magnitude-based visual encoding: bold colors for large shifts, muted for small
- Added "View all" link on dashboard and "Shifts" entry in Meta nav dropdown

## Test plan

- [x] Python tests pass (333 tests, including new slug validation and structure tests)
- [x] Frontend tests pass (106 tests, including new ShiftsClient component tests and getMetaEvolution data loader tests)
- [x] TypeScript compiles clean
- [x] Pre-commit hooks pass (ruff, next build, typecheck, vitest)
- [ ] Manual: verify shifts page renders at `/{format}/shifts`
- [ ] Manual: verify direction and archetype filters work
- [ ] Manual: verify dashboard "View all" link navigates correctly
- [ ] Manual: verify mobile responsiveness

Closes #39

Generated with [Claude Code](https://claude.com/claude-code)