### PR TITLE
Theme Preview: Dramatic

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -9,14 +9,14 @@
 }
 
 @theme {
-  /* Base palette */
-  --color-surface-900: #0a0c10;
-  --color-surface-800: #0f1218;
-  --color-surface-700: #151921;
-  --color-surface-600: #1c2130;
-  --color-surface-500: #2a3040;
-  --color-surface-400: #3d4556;
-  --color-surface-300: #6b7280;
+  /* Base palette — Dramatic */
+  --color-surface-900: #09090B;
+  --color-surface-800: #111113;
+  --color-surface-700: #18181B;
+  --color-surface-600: #27272A;
+  --color-surface-500: #3F3F46;
+  --color-surface-400: #52525B;
+  --color-surface-300: #71717A;
 
   /* Tier colors */
   --color-tier-s: #f59e0b;
@@ -39,15 +39,15 @@
   --color-accent: #f59e0b;
   --color-accent-dim: #92640a;
 
-  /* Typography */
-  --font-display: "Instrument Sans", sans-serif;
-  --font-body: "IBM Plex Sans", sans-serif;
-  --font-mono: "IBM Plex Mono", monospace;
+  /* Typography — Dramatic */
+  --font-display: "Outfit", sans-serif;
+  --font-body: "Outfit", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
 }
 
 body {
   background-color: var(--color-surface-900);
-  color: #e2e8f0;
+  color: #FAFAFA;
   font-family: var(--font-body);
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,23 +1,23 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import { Instrument_Sans, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
+import { Outfit, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const instrumentSans = Instrument_Sans({
+const outfit = Outfit({
   subsets: ["latin"],
-  weight: ["600", "700"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-display",
   display: "swap",
 });
 
-const ibmPlexSans = IBM_Plex_Sans({
+const outfitBody = Outfit({
   subsets: ["latin"],
   weight: ["400", "500"],
   variable: "--font-body",
   display: "swap",
 });
 
-const ibmPlexMono = IBM_Plex_Mono({
+const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   weight: ["400"],
   variable: "--font-mono",
@@ -44,7 +44,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${instrumentSans.variable} ${ibmPlexSans.variable} ${ibmPlexMono.variable} ${pokemonClassic.variable}`}
+      className={`${outfit.variable} ${outfitBody.variable} ${jetbrainsMono.variable} ${pokemonClassic.variable}`}
     >
       <body className="min-h-screen antialiased">
         {children}


### PR DESCRIPTION
Applies the Dramatic TypeUI theme to Scout for visual comparison.

Changes:
- Surface palette: zinc-based near-black (#09090B) with neutral gray ramp
- Fonts: Outfit (display + body), JetBrains Mono (data)
- Text: #FAFAFA primary

Tier colors, signal colors, and amber accent are unchanged.

> This is a preview branch for theme evaluation — not intended for merge.