### PR TITLE
Theme Preview: Luxury

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -9,14 +9,14 @@
 }
 
 @theme {
-  /* Base palette */
-  --color-surface-900: #0a0c10;
-  --color-surface-800: #0f1218;
-  --color-surface-700: #151921;
-  --color-surface-600: #1c2130;
-  --color-surface-500: #2a3040;
-  --color-surface-400: #3d4556;
-  --color-surface-300: #6b7280;
+  /* Base palette — Luxury */
+  --color-surface-900: #000000;
+  --color-surface-800: #0A0A0A;
+  --color-surface-700: #141414;
+  --color-surface-600: #1F1F1F;
+  --color-surface-500: #2A2A2A;
+  --color-surface-400: #404040;
+  --color-surface-300: #666666;
 
   /* Tier colors */
   --color-tier-s: #f59e0b;
@@ -39,15 +39,15 @@
   --color-accent: #f59e0b;
   --color-accent-dim: #92640a;
 
-  /* Typography */
-  --font-display: "Instrument Sans", sans-serif;
-  --font-body: "IBM Plex Sans", sans-serif;
-  --font-mono: "IBM Plex Mono", monospace;
+  /* Typography — Luxury */
+  --font-display: "Oswald", sans-serif;
+  --font-body: "Oswald", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
 }
 
 body {
   background-color: var(--color-surface-900);
-  color: #e2e8f0;
+  color: #FFFFFF;
   font-family: var(--font-body);
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,23 +1,23 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import { Instrument_Sans, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
+import { Oswald, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const instrumentSans = Instrument_Sans({
+const oswald = Oswald({
   subsets: ["latin"],
-  weight: ["600", "700"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-display",
   display: "swap",
 });
 
-const ibmPlexSans = IBM_Plex_Sans({
+const oswaldBody = Oswald({
   subsets: ["latin"],
   weight: ["400", "500"],
   variable: "--font-body",
   display: "swap",
 });
 
-const ibmPlexMono = IBM_Plex_Mono({
+const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   weight: ["400"],
   variable: "--font-mono",
@@ -44,7 +44,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${instrumentSans.variable} ${ibmPlexSans.variable} ${ibmPlexMono.variable} ${pokemonClassic.variable}`}
+      className={`${oswald.variable} ${oswaldBody.variable} ${jetbrainsMono.variable} ${pokemonClassic.variable}`}
     >
       <body className="min-h-screen antialiased">
         {children}


### PR DESCRIPTION
Applies the Luxury TypeUI theme to Scout for visual comparison.

Changes:
- Surface palette: pure black (#000000) with monochromatic gray ramp
- Fonts: Oswald (display + body), JetBrains Mono (data)
- Text: #FFFFFF primary

Tier colors, signal colors, and amber accent are unchanged.

> This is a preview branch for theme evaluation — not intended for merge.