### PR TITLE
Theme Preview: Cosmic

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -9,14 +9,14 @@
 }
 
 @theme {
-  /* Base palette */
-  --color-surface-900: #0a0c10;
-  --color-surface-800: #0f1218;
-  --color-surface-700: #151921;
-  --color-surface-600: #1c2130;
-  --color-surface-500: #2a3040;
-  --color-surface-400: #3d4556;
-  --color-surface-300: #6b7280;
+  /* Base palette — Cosmic */
+  --color-surface-900: #070B1A;
+  --color-surface-800: #0D1128;
+  --color-surface-700: #141838;
+  --color-surface-600: #1E2248;
+  --color-surface-500: #2A3058;
+  --color-surface-400: #3E4470;
+  --color-surface-300: #6870A0;
 
   /* Tier colors */
   --color-tier-s: #f59e0b;
@@ -39,15 +39,15 @@
   --color-accent: #f59e0b;
   --color-accent-dim: #92640a;
 
-  /* Typography */
-  --font-display: "Instrument Sans", sans-serif;
+  /* Typography — Cosmic */
+  --font-display: "Audiowide", sans-serif;
   --font-body: "IBM Plex Sans", sans-serif;
-  --font-mono: "IBM Plex Mono", monospace;
+  --font-mono: "JetBrains Mono", monospace;
 }
 
 body {
   background-color: var(--color-surface-900);
-  color: #e2e8f0;
+  color: #E8EAFF;
   font-family: var(--font-body);
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import { Instrument_Sans, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
+import { Audiowide, IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const instrumentSans = Instrument_Sans({
+const audiowide = Audiowide({
   subsets: ["latin"],
-  weight: ["600", "700"],
+  weight: ["400"],
   variable: "--font-display",
   display: "swap",
 });
@@ -17,7 +17,7 @@ const ibmPlexSans = IBM_Plex_Sans({
   display: "swap",
 });
 
-const ibmPlexMono = IBM_Plex_Mono({
+const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   weight: ["400"],
   variable: "--font-mono",
@@ -44,7 +44,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${instrumentSans.variable} ${ibmPlexSans.variable} ${ibmPlexMono.variable} ${pokemonClassic.variable}`}
+      className={`${audiowide.variable} ${ibmPlexSans.variable} ${jetbrainsMono.variable} ${pokemonClassic.variable}`}
     >
       <body className="min-h-screen antialiased">
         {children}


### PR DESCRIPTION
Applies the Cosmic TypeUI theme to Scout for visual comparison.

Changes:
- Surface palette: deep-space navy (#070B1A) with indigo-tinted gray ramp
- Fonts: Audiowide (display), IBM Plex Sans (body), JetBrains Mono (data)
- Text: #E8EAFF (cool-shifted white)

Tier colors, signal colors, and amber accent are unchanged.

> This is a preview branch for theme evaluation — not intended for merge.