### PR TITLE
Theme Preview: Neon

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -9,14 +9,14 @@
 }
 
 @theme {
-  /* Base palette */
-  --color-surface-900: #0a0c10;
-  --color-surface-800: #0f1218;
-  --color-surface-700: #151921;
-  --color-surface-600: #1c2130;
-  --color-surface-500: #2a3040;
-  --color-surface-400: #3d4556;
-  --color-surface-300: #6b7280;
+  /* Base palette — Neon */
+  --color-surface-900: #09090B;
+  --color-surface-800: #0D1018;
+  --color-surface-700: #131620;
+  --color-surface-600: #1A1E2E;
+  --color-surface-500: #252A3A;
+  --color-surface-400: #384050;
+  --color-surface-300: #6B7280;
 
   /* Tier colors */
   --color-tier-s: #f59e0b;
@@ -39,15 +39,15 @@
   --color-accent: #f59e0b;
   --color-accent-dim: #92640a;
 
-  /* Typography */
-  --font-display: "Instrument Sans", sans-serif;
-  --font-body: "IBM Plex Sans", sans-serif;
-  --font-mono: "IBM Plex Mono", monospace;
+  /* Typography — Neon */
+  --font-display: "Roboto", sans-serif;
+  --font-body: "Roboto", sans-serif;
+  --font-mono: "Source Code Pro", monospace;
 }
 
 body {
   background-color: var(--color-surface-900);
-  color: #e2e8f0;
+  color: #F0F2F5;
   font-family: var(--font-body);
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,23 +1,23 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import { Instrument_Sans, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
+import { Roboto, Source_Code_Pro } from "next/font/google";
 import "./globals.css";
 
-const instrumentSans = Instrument_Sans({
+const roboto = Roboto({
   subsets: ["latin"],
-  weight: ["600", "700"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-display",
   display: "swap",
 });
 
-const ibmPlexSans = IBM_Plex_Sans({
+const robotoBody = Roboto({
   subsets: ["latin"],
   weight: ["400", "500"],
   variable: "--font-body",
   display: "swap",
 });
 
-const ibmPlexMono = IBM_Plex_Mono({
+const sourceCodePro = Source_Code_Pro({
   subsets: ["latin"],
   weight: ["400"],
   variable: "--font-mono",
@@ -44,7 +44,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${instrumentSans.variable} ${ibmPlexSans.variable} ${ibmPlexMono.variable} ${pokemonClassic.variable}`}
+      className={`${roboto.variable} ${robotoBody.variable} ${sourceCodePro.variable} ${pokemonClassic.variable}`}
     >
       <body className="min-h-screen antialiased">
         {children}


### PR DESCRIPTION
Applies the Neon TypeUI theme to Scout for visual comparison.

Changes:
- Surface palette: near-black (#09090B) with cool blue-tinted gray ramp
- Fonts: Roboto (display + body), Source Code Pro (data)
- Text: #F0F2F5 primary

Tier colors, signal colors, and amber accent are unchanged.

> This is a preview branch for theme evaluation — not intended for merge.