### PR TITLE
test: expand test coverage across Python and frontend (+429 tests)

### DIFF
--- a/analysis/archetype.py
+++ b/analysis/archetype.py
@@ -93,6 +93,8 @@ SPRITE_ARCHETYPE_MAP: dict[str, str] = {
     # Chien-Pao
     "chien-pao": "Chien-Pao ex",
     "baxcalibur-chien-pao": "Chien-Pao ex",
+    # Porygon-Z
+    "porygon-z": "Porygon-Z",
     # Lost Zone
     "comfey-giratina": "Lost Zone Giratina",
     "comfey-sableye": "Lost Zone Box",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,8 @@ def db() -> sqlite3.Connection:
 
     # --- Cards table (for JP→EN translation + image URLs) ---
     conn.executemany(
-        "INSERT INTO cards (id, name_en, name_jp, set_code, image_url) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO cards (id, name_en, name_jp, set_code, image_url, supertype, rotation_legal) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
         [
             (
                 "sv5-001",
@@ -96,6 +97,8 @@ def db() -> sqlite3.Connection:
                 "リザードンex",
                 "sv5",
                 "https://images.pokemontcg.io/sv5/001.png",
+                "Pokemon",
+                1,
             ),
             (
                 "sv5-002",
@@ -103,6 +106,8 @@ def db() -> sqlite3.Connection:
                 "ドラパルトex",
                 "sv5",
                 "https://images.pokemontcg.io/sv5/002.png",
+                "Pokemon",
+                1,
             ),
             (
                 "sv5-003",
@@ -110,6 +115,17 @@ def db() -> sqlite3.Connection:
                 "ふしぎなアメ",
                 "sv5",
                 "https://images.pokemontcg.io/sv5/003.png",
+                "Trainer",
+                1,
+            ),
+            (
+                "sv5-rotated",
+                "Rotated Card",
+                "ローテカード",
+                "sv1",
+                "https://images.pokemontcg.io/sv1/001.png",
+                "Trainer",
+                0,
             ),
         ],
     )
@@ -257,6 +273,10 @@ def db_integration() -> sqlite3.Connection:
     for pid in gholdengo_pids:
         decklist_rows.append((pid, "card-gholdengo", "Gholdengo ex", 2))
 
+    # Rotated card (rotation_legal=0) in all open placements — buylist should exclude
+    for pid in range(1, 13):
+        decklist_rows.append((pid, "sv1-rotated", "Rotated Card", 1))
+
     # Late-week-only card for trend testing (weeks 3-4 only)
     for pid in [7, 8, 9, 10, 11, 12]:
         decklist_rows.append((pid, "card-judge", "Judge", 2))
@@ -274,7 +294,8 @@ def db_integration() -> sqlite3.Connection:
 
     # --- Cards table ---
     conn.executemany(
-        "INSERT INTO cards (id, name_en, name_jp, set_code, image_url, supertype) VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO cards (id, name_en, name_jp, set_code, image_url, supertype, rotation_legal) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
         [
             (
                 "sv5-001",
@@ -283,6 +304,7 @@ def db_integration() -> sqlite3.Connection:
                 "sv5",
                 "https://img/sv5-001.png",
                 "Pokemon",
+                1,
             ),
             (
                 "sv5-002",
@@ -291,8 +313,17 @@ def db_integration() -> sqlite3.Connection:
                 "sv5",
                 "https://img/sv5-002.png",
                 "Pokemon",
+                1,
             ),
-            ("sv5-003", "Rare Candy", "ふしぎなアメ", "sv5", "https://img/sv5-003.png", "Trainer"),
+            (
+                "sv5-003",
+                "Rare Candy",
+                "ふしぎなアメ",
+                "sv5",
+                "https://img/sv5-003.png",
+                "Trainer",
+                1,
+            ),
             (
                 "sv5-004",
                 "Raging Bolt ex",
@@ -300,6 +331,7 @@ def db_integration() -> sqlite3.Connection:
                 "sv5",
                 "https://img/sv5-004.png",
                 "Pokemon",
+                1,
             ),
             (
                 "sv5-005",
@@ -308,6 +340,7 @@ def db_integration() -> sqlite3.Connection:
                 "sv5",
                 "https://img/sv5-005.png",
                 "Pokemon",
+                1,
             ),
             (
                 "sv5-006",
@@ -316,6 +349,16 @@ def db_integration() -> sqlite3.Connection:
                 "sv5",
                 "https://img/sv5-006.png",
                 "Pokemon",
+                1,
+            ),
+            (
+                "sv1-rotated",
+                "Rotated Card",
+                "ローテカード",
+                "sv1",
+                "https://img/sv1-001.png",
+                "Trainer",
+                0,
             ),
         ],
     )

--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -1,11 +1,16 @@
 """Tests for analysis/archetype.py — sprite key building and archetype normalization."""
 
+import re
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from analysis.archetype import (
+    _COMPOSITE_SPRITE_FILENAMES,
+    SPRITE_ARCHETYPE_MAP,
     _derive_name_from_key,
     _sprite_key_to_filenames,
     build_sprite_key,
@@ -114,3 +119,37 @@ class TestSpriteKeyToFilenames:
 
     def test_empty_key(self):
         assert _sprite_key_to_filenames("") == []
+
+
+# --- SPRITE_ARCHETYPE_MAP consistency ---
+
+KEY_PATTERN = re.compile(r"^[a-z0-9-]+$")
+
+
+class TestSpriteMapConsistency:
+    @pytest.mark.parametrize("key", list(_COMPOSITE_SPRITE_FILENAMES.keys()))
+    def test_composite_keys_in_archetype_map(self, key):
+        assert key in SPRITE_ARCHETYPE_MAP, (
+            f"Composite key {key!r} missing from SPRITE_ARCHETYPE_MAP"
+        )
+
+    @pytest.mark.parametrize("key", list(SPRITE_ARCHETYPE_MAP.keys()))
+    def test_sprite_keys_are_lowercase_hyphenated(self, key):
+        assert KEY_PATTERN.match(key), f"Key {key!r} does not match ^[a-z0-9-]+$"
+
+    @pytest.mark.parametrize("key,name", list(SPRITE_ARCHETYPE_MAP.items()))
+    def test_no_empty_archetype_names(self, key, name):
+        assert isinstance(name, str) and name.strip(), (
+            f"SPRITE_ARCHETYPE_MAP[{key!r}] has empty or non-string value"
+        )
+
+    @pytest.mark.parametrize(
+        "key,filenames",
+        list(_COMPOSITE_SPRITE_FILENAMES.items()),
+    )
+    def test_composite_filenames_are_valid(self, key, filenames):
+        for filename in filenames:
+            assert isinstance(filename, str) and KEY_PATTERN.match(filename), (
+                f"Filename {filename!r} in _COMPOSITE_SPRITE_FILENAMES[{key!r}] "
+                f"is invalid (must match ^[a-z0-9-]+$)"
+            )

--- a/tests/test_buylist.py
+++ b/tests/test_buylist.py
@@ -1,0 +1,482 @@
+"""Tests for analysis/buylist.py — priority-scored buy list generation."""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from analysis.buylist import BASIC_ENERGY_NAMES, generate_buylist
+from db import SCHEMA
+
+
+@pytest.fixture()
+def db_buylist() -> sqlite3.Connection:
+    """In-memory SQLite database tailored for buylist tests.
+
+    Layout:
+    - 3 open tournaments, 1 senior (filtered out by open_placements view)
+    - 3 archetypes with tiers: S (Charizard ex), A (Dragapult ex), B (Raging Bolt ex)
+    - 2 placements per archetype (all open division), each with decklists
+    - Cards table with rotation_legal=1 and rotation_legal=0 entries
+    - A basic energy card in decklists (should be excluded)
+    - Pokemon and Trainer supertypes for core threshold testing
+    - One card_id not in the cards table (unresolved, should be included)
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(SCHEMA)
+
+    # --- Tournaments ---
+    conn.executemany(
+        "INSERT INTO tournaments (id, name, date, player_count, division) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("t1", "Osaka CL", "2026-02-01", 64, "open"),
+            ("t2", "Tokyo CL", "2026-02-08", 64, "open"),
+            ("t3", "Nagoya CL", "2026-02-15", 64, "open"),
+            ("t4", "Senior Cup", "2026-02-10", 32, "senior"),
+        ],
+    )
+
+    # --- Placements ---
+    # Charizard ex: placements 1, 2 (open)
+    # Dragapult ex: placements 3, 4 (open)
+    # Raging Bolt ex: placements 5, 6 (open)
+    # Senior placement 7 (should be invisible to open_placements)
+    conn.executemany(
+        "INSERT INTO placements (id, tournament_id, standing, player_name, archetype) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            (1, "t1", 1, "Alice", "Charizard ex"),
+            (2, "t2", 2, "Bob", "Charizard ex"),
+            (3, "t1", 3, "Charlie", "Dragapult ex"),
+            (4, "t2", 4, "Diana", "Dragapult ex"),
+            (5, "t3", 1, "Eve", "Raging Bolt ex"),
+            (6, "t3", 8, "Frank", "Raging Bolt ex"),
+            (7, "t4", 1, "Greta", "Charizard ex"),
+        ],
+    )
+
+    # --- Cards table ---
+    conn.executemany(
+        "INSERT INTO cards (id, name_en, name_jp, set_code, set_number, image_url, supertype, rotation_legal) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("card-zard", "Charizard ex", "リザードンex", "sv5", "001", None, "Pokemon", 1),
+            ("card-draga", "Dragapult ex", "ドラパルトex", "sv5", "002", None, "Pokemon", 1),
+            ("card-bolt", "Raging Bolt ex", "タケルライコex", "sv5", "003", None, "Pokemon", 1),
+            ("card-nest", "Nest Ball", "ネストボール", "sv5", "100", None, "Trainer", 1),
+            ("card-boss", "Boss's Orders", "ボスの指令", "sv5", "101", None, "Trainer", 1),
+            ("card-rotated", "Old Trainer", "旧トレーナー", "sv1", "050", None, "Trainer", 0),
+            (
+                "card-energy",
+                "Basic Fire Energy",
+                "基本炎エネルギー",
+                "sve",
+                "001",
+                None,
+                "Energy",
+                1,
+            ),
+        ],
+    )
+
+    # --- Decklist cards ---
+    decklist_rows = []
+
+    # Charizard ex placements (1, 2): shared core cards
+    for pid in [1, 2]:
+        decklist_rows.extend(
+            [
+                (pid, "card-zard", "Charizard ex", 3),  # Pokemon, avg 3, inclusion 100%
+                (pid, "card-nest", "Nest Ball", 4),  # Trainer, avg 4, inclusion 100%
+                (pid, "card-boss", "Boss's Orders", 2),  # Trainer, avg 2, inclusion 100%
+                (pid, "card-rotated", "Old Trainer", 2),  # rotation_legal=0, should be excluded
+                (pid, "card-energy", "Basic Fire Energy", 4),  # basic energy, should be excluded
+            ]
+        )
+
+    # Dragapult ex placements (3, 4): share some cards with Charizard
+    for pid in [3, 4]:
+        decklist_rows.extend(
+            [
+                (pid, "card-draga", "Dragapult ex", 3),  # Pokemon, avg 3, inclusion 100%
+                (pid, "card-nest", "Nest Ball", 4),  # shared with Charizard
+                (pid, "card-boss", "Boss's Orders", 2),  # shared with Charizard
+            ]
+        )
+
+    # Raging Bolt ex placements (5, 6): share Nest Ball and Boss
+    for pid in [5, 6]:
+        decklist_rows.extend(
+            [
+                (pid, "card-bolt", "Raging Bolt ex", 3),  # Pokemon, avg 3, inclusion 100%
+                (pid, "card-nest", "Nest Ball", 4),  # shared across all 3 archetypes
+                (pid, "card-boss", "Boss's Orders", 2),  # shared across all 3 archetypes
+            ]
+        )
+
+    # One placement with an unresolved card (not in cards table)
+    decklist_rows.append((1, "card-unknown", "Mystery Card", 2))
+
+    conn.executemany(
+        "INSERT INTO decklist_cards (placement_id, card_id, card_name, count) VALUES (?, ?, ?, ?)",
+        decklist_rows,
+    )
+
+    # --- Meta snapshot ---
+    conn.execute(
+        "INSERT INTO meta_snapshots (id, generated_at, tournament_count, deck_count) "
+        "VALUES (?, ?, ?, ?)",
+        (1, "2026-03-01T00:00:00", 3, 6),
+    )
+    conn.executemany(
+        "INSERT INTO archetype_stats (snapshot_id, archetype, meta_share, deck_count, best_placement, tier, weighted_share) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, "Charizard ex", 33.3, 2, 1, "S", 40.0),
+            (1, "Dragapult ex", 33.3, 2, 3, "A", 30.0),
+            (1, "Raging Bolt ex", 33.3, 2, 1, "B", 30.0),
+        ],
+    )
+
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+# --- Basic return behavior ---
+
+
+class TestBuylistBasicBehavior:
+    """Tests for fundamental return conditions."""
+
+    def test_returns_nonempty_for_sab_archetypes(self, db_buylist):
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        assert len(result) > 0
+
+    def test_returns_list_of_dicts(self, db_buylist):
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        assert isinstance(result, list)
+        for item in result:
+            assert isinstance(item, dict)
+
+    def test_empty_for_nonexistent_snapshot(self, db_buylist):
+        result = generate_buylist(db_buylist, snapshot_id=999)
+        assert result == []
+
+    def test_empty_when_only_rogue_and_c_tiers(self, db_buylist):
+        """All archetypes are Rogue or C tier -- no S/A/B means empty buylist."""
+        db_buylist.execute("DELETE FROM archetype_stats")
+        db_buylist.executemany(
+            "INSERT INTO archetype_stats (snapshot_id, archetype, meta_share, deck_count, best_placement, tier, weighted_share) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (1, "Charizard ex", 2.0, 2, 1, "C", 3.0),
+                (1, "Dragapult ex", 0.5, 1, 3, "Rogue", 0.8),
+            ],
+        )
+        db_buylist.commit()
+
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        assert result == []
+
+    def test_empty_for_empty_snapshot(self, db_buylist):
+        """Snapshot exists but has no archetype_stats rows."""
+        db_buylist.execute(
+            "INSERT INTO meta_snapshots (id, generated_at, tournament_count, deck_count) "
+            "VALUES (?, ?, ?, ?)",
+            (99, "2026-03-15T00:00:00", 0, 0),
+        )
+        db_buylist.commit()
+
+        result = generate_buylist(db_buylist, snapshot_id=99)
+        assert result == []
+
+
+# --- Card filtering ---
+
+
+class TestBuylistCardFiltering:
+    """Tests for energy exclusion and rotation legality filtering."""
+
+    def test_excludes_basic_energy_cards(self, db_buylist):
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        card_names = {r["card_name"] for r in result}
+        assert "Basic Fire Energy" not in card_names
+
+    def test_basic_energy_names_set_is_nonempty(self):
+        """Sanity check that the BASIC_ENERGY_NAMES constant is populated."""
+        assert len(BASIC_ENERGY_NAMES) > 0
+        assert "Basic Fire Energy" in BASIC_ENERGY_NAMES
+        assert "Fire Energy" in BASIC_ENERGY_NAMES
+
+    def test_excludes_rotation_illegal_cards(self, db_buylist):
+        """Cards with rotation_legal=0 in the cards table are excluded."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        card_ids = {r["card_id"] for r in result if r["card_id"] is not None}
+        assert "card-rotated" not in card_ids
+        card_names = {r["card_name"] for r in result}
+        assert "Old Trainer" not in card_names
+
+    def test_includes_cards_not_in_cards_table(self, db_buylist):
+        """Cards with IDs not in the cards table bypass rotation check and are included."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        card_names = {r["card_name"] for r in result}
+        assert "Mystery Card" in card_names
+
+    def test_unresolved_card_has_null_fields(self, db_buylist):
+        """Cards not in cards table should have card_id=None, set_code=None, set_number=None."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        mystery = next(r for r in result if r["card_name"] == "Mystery Card")
+        assert mystery["card_id"] is None
+        assert mystery["set_code"] is None
+        assert mystery["set_number"] is None
+
+
+# --- Priority scoring ---
+
+
+class TestBuylistPriorityScoring:
+    """Tests for priority_score calculation and sorting."""
+
+    def test_priority_score_uses_tier_weights(self, db_buylist):
+        """priority_score += avg_copies * tier_weight per archetype.
+
+        Nest Ball: avg 4 copies in all 3 archetypes.
+        S(Charizard) contribution: 4 * 5 = 20
+        A(Dragapult) contribution: 4 * 3 = 12
+        B(Raging Bolt) contribution: 4 * 1 = 4
+        Total: 36.0
+        """
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        nest = next(r for r in result if r["card_name"] == "Nest Ball")
+        assert nest["priority_score"] == 36.0
+
+    def test_single_archetype_priority_score(self, db_buylist):
+        """Charizard ex card only in S-tier archetype: avg 3 * weight 5 = 15.0."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        zard = next(r for r in result if r["card_name"] == "Charizard ex")
+        assert zard["priority_score"] == 15.0
+
+    def test_b_tier_priority_score(self, db_buylist):
+        """Raging Bolt ex only in B-tier: avg 3 * weight 1 = 3.0."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        bolt = next(r for r in result if r["card_name"] == "Raging Bolt ex")
+        assert bolt["priority_score"] == 3.0
+
+    def test_results_sorted_by_priority_score_descending(self, db_buylist):
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        scores = [r["priority_score"] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_boss_orders_cross_archetype_score(self, db_buylist):
+        """Boss's Orders: avg 2 copies in S + A + B archetypes.
+
+        S: 2 * 5 = 10, A: 2 * 3 = 6, B: 2 * 1 = 2 => total 18.0
+        """
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        boss = next(r for r in result if r["card_name"] == "Boss's Orders")
+        assert boss["priority_score"] == 18.0
+
+
+# --- Cross-archetype aggregation ---
+
+
+class TestBuylistCrossArchetypeAggregation:
+    """Tests for cross-archetype max inclusion_rate and archetype lists."""
+
+    def test_max_inclusion_rate_across_archetypes(self, db_buylist):
+        """Nest Ball is in 100% of decks in all 3 archetypes -- max inclusion_rate = 1.0."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        nest = next(r for r in result if r["card_name"] == "Nest Ball")
+        assert nest["inclusion_rate"] == 1.0
+
+    def test_archetype_list_completeness(self, db_buylist):
+        """Nest Ball should list all 3 archetypes it appears in."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        nest = next(r for r in result if r["card_name"] == "Nest Ball")
+        assert set(nest["archetypes"]) == {"Charizard ex", "Dragapult ex", "Raging Bolt ex"}
+
+    def test_single_archetype_card(self, db_buylist):
+        """Charizard ex card only appears in the Charizard ex archetype."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        zard = next(r for r in result if r["card_name"] == "Charizard ex")
+        assert zard["archetypes"] == ["Charizard ex"]
+
+
+# --- Urgency classification ---
+
+
+class TestBuylistUrgency:
+    """Tests for URGENT / HIGH / MODERATE urgency labels."""
+
+    def test_urgent_core_in_two_sa_archetypes(self, db_buylist):
+        """Nest Ball: core (inclusion >= 0.75, avg 4 >= 2 for Trainer), in S + A archetypes.
+
+        Core in at least 2 S/A archetypes => URGENT.
+        """
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        nest = next(r for r in result if r["card_name"] == "Nest Ball")
+        assert nest["urgency"] == "URGENT"
+
+    def test_high_core_in_one_sa_archetype(self, db_buylist):
+        """Charizard ex: core Pokemon (inclusion 1.0, avg 3 >= 3), in 1 S-tier archetype.
+
+        Core in exactly 1 S/A archetype => HIGH.
+        """
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        zard = next(r for r in result if r["card_name"] == "Charizard ex")
+        assert zard["urgency"] == "HIGH"
+
+    def test_high_any_card_in_three_or_more_archetypes(self, db_buylist):
+        """Boss's Orders: avg 2, inclusion 1.0, Trainer threshold 2 => core.
+
+        Core in 2 S/A archetypes (S + A) => actually URGENT.
+        But we verify the >=3 archetype rule separately below.
+        """
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        boss = next(r for r in result if r["card_name"] == "Boss's Orders")
+        # Boss is core (Trainer, avg 2 >= 2, inclusion 1.0) and in S + A => URGENT
+        assert boss["urgency"] == "URGENT"
+
+    def test_high_via_archetype_count(self, db_buylist):
+        """A flex card in >=3 archetypes should be HIGH even without core status."""
+        # Add a flex card (low copies) to all 3 archetypes
+        for pid in [1, 3, 5]:
+            db_buylist.execute(
+                "INSERT INTO decklist_cards (placement_id, card_id, card_name, count) VALUES (?, ?, ?, ?)",
+                (pid, "card-flex", "Flex Tool", 1),
+            )
+        db_buylist.execute(
+            "INSERT INTO cards (id, name_en, name_jp, set_code, set_number, image_url, supertype, rotation_legal) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("card-flex", "Flex Tool", "フレックス", "sv5", "200", None, "Trainer", 1),
+        )
+        db_buylist.commit()
+
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        flex = next(r for r in result if r["card_name"] == "Flex Tool")
+        # inclusion_rate = 0.5 (1 of 2 decks per archetype) => not core
+        # But appears in 3 archetypes => HIGH
+        assert flex["core_flex"] == "flex"
+        assert flex["urgency"] == "HIGH"
+
+    def test_moderate_default(self, db_buylist):
+        """A card in only one B-tier archetype with flex status should be MODERATE."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        bolt = next(r for r in result if r["card_name"] == "Raging Bolt ex")
+        # Raging Bolt ex: core Pokemon in B-tier only (no S/A), 1 archetype => MODERATE
+        assert bolt["urgency"] == "MODERATE"
+
+
+# --- Core vs flex classification ---
+
+
+class TestBuylistCoreFlex:
+    """Tests for core/flex determination based on inclusion rate and avg copies."""
+
+    def test_pokemon_core_threshold(self, db_buylist):
+        """Pokemon card: core when inclusion >= 0.75 AND avg_copies >= 3."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        zard = next(r for r in result if r["card_name"] == "Charizard ex")
+        # inclusion_rate = 1.0 (2/2 decks), avg_copies = 3.0
+        assert zard["core_flex"] == "core"
+        assert zard["avg_copies"] == 3.0
+        assert zard["inclusion_rate"] == 1.0
+
+    def test_trainer_core_threshold(self, db_buylist):
+        """Trainer card: core when inclusion >= 0.75 AND avg_copies >= 2."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        boss = next(r for r in result if r["card_name"] == "Boss's Orders")
+        # inclusion_rate = 1.0, avg_copies = 2.0 (Trainer threshold = 2)
+        assert boss["core_flex"] == "core"
+
+    def test_pokemon_flex_when_low_copies(self, db_buylist):
+        """A Pokemon with high inclusion but avg_copies < 3 is flex."""
+        # Add a low-copy Pokemon to both Charizard placements
+        for pid in [1, 2]:
+            db_buylist.execute(
+                "INSERT INTO decklist_cards (placement_id, card_id, card_name, count) VALUES (?, ?, ?, ?)",
+                (pid, "card-tech-poke", "Tech Pokemon", 1),
+            )
+        db_buylist.execute(
+            "INSERT INTO cards (id, name_en, name_jp, set_code, set_number, image_url, supertype, rotation_legal) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("card-tech-poke", "Tech Pokemon", "テクポケ", "sv5", "150", None, "Pokemon", 1),
+        )
+        db_buylist.commit()
+
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        tech = next(r for r in result if r["card_name"] == "Tech Pokemon")
+        # inclusion = 1.0 (2/2 in Charizard), avg_copies = 1.0, Pokemon threshold = 3
+        assert tech["core_flex"] == "flex"
+
+    def test_flex_when_low_inclusion(self, db_buylist):
+        """A card in only 1 of 2 decks (50% inclusion) is flex regardless of copy count."""
+        # Add a high-copy card to only one Charizard placement
+        db_buylist.execute(
+            "INSERT INTO decklist_cards (placement_id, card_id, card_name, count) VALUES (?, ?, ?, ?)",
+            (1, "card-niche", "Niche Trainer", 4),
+        )
+        db_buylist.execute(
+            "INSERT INTO cards (id, name_en, name_jp, set_code, set_number, image_url, supertype, rotation_legal) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("card-niche", "Niche Trainer", "ニッチ", "sv5", "160", None, "Trainer", 1),
+        )
+        db_buylist.commit()
+
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        niche = next(r for r in result if r["card_name"] == "Niche Trainer")
+        # inclusion = 0.5 (1/2 decks) < 0.75 => flex
+        assert niche["core_flex"] == "flex"
+
+
+# --- Result structure ---
+
+
+class TestBuylistResultStructure:
+    """Tests for the shape and fields of result dicts."""
+
+    EXPECTED_KEYS = {
+        "card_name",
+        "card_id",
+        "set_code",
+        "set_number",
+        "priority_score",
+        "urgency",
+        "core_flex",
+        "archetypes",
+        "avg_copies",
+        "inclusion_rate",
+    }
+
+    def test_result_dict_keys(self, db_buylist):
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        for item in result:
+            assert set(item.keys()) == self.EXPECTED_KEYS
+
+    def test_resolved_card_has_set_info(self, db_buylist):
+        """Cards present in the cards table should have set_code and set_number."""
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        nest = next(r for r in result if r["card_name"] == "Nest Ball")
+        assert nest["card_id"] == "card-nest"
+        assert nest["set_code"] == "sv5"
+        assert nest["set_number"] == "100"
+
+    def test_senior_division_excluded(self, db_buylist):
+        """Senior division placement (id=7) should not affect buylist results.
+
+        The Charizard ex archetype has 2 open placements (ids 1, 2) and 1 senior (id 7).
+        Decklist analysis should only see 2 decks for Charizard.
+        """
+        result = generate_buylist(db_buylist, snapshot_id=1)
+        zard = next(r for r in result if r["card_name"] == "Charizard ex")
+        # avg_copies = 3.0 (from 2 open decks each with count=3)
+        # If senior were included, there would be 0 decks for pid=7 (no decklist_cards for pid=7)
+        # which would still give avg 3.0 but inclusion_rate would change.
+        # Since pid=7 has no decklist_cards, this validates the view filters it out.
+        assert zard["inclusion_rate"] == 1.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,107 @@
+"""Tests for config.py — validation of configuration invariants."""
+
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from config import (
+    CORE_AVG_COPIES_OTHER,
+    CORE_AVG_COPIES_POKEMON,
+    CORE_INCLUSION_RATE,
+    FORMATS,
+    PLACEMENT_WEIGHT_DEFAULT,
+    PLACEMENT_WEIGHTS,
+    TIER_THRESHOLDS,
+    TIER_WEIGHTS,
+)
+
+
+class TestTierThresholds:
+    def test_descending_order(self):
+        """S > A > B > C thresholds."""
+        ordered = ["S", "A", "B", "C"]
+        values = [TIER_THRESHOLDS[k] for k in ordered]
+        for i in range(len(values) - 1):
+            assert values[i] > values[i + 1], (
+                f"TIER_THRESHOLDS[{ordered[i]!r}]={values[i]} should be > "
+                f"TIER_THRESHOLDS[{ordered[i + 1]!r}]={values[i + 1]}"
+            )
+
+    def test_all_positive(self):
+        for tier, value in TIER_THRESHOLDS.items():
+            assert value > 0, f"TIER_THRESHOLDS[{tier!r}] should be positive, got {value}"
+
+
+class TestPlacementWeights:
+    def test_all_positive(self):
+        for placement, weight in PLACEMENT_WEIGHTS.items():
+            assert weight > 0, f"PLACEMENT_WEIGHTS[{placement}] should be > 0, got {weight}"
+        assert PLACEMENT_WEIGHT_DEFAULT > 0
+
+    def test_descending_by_placement(self):
+        """Higher placements (lower number) should have >= weight than lower placements."""
+        placements = sorted(PLACEMENT_WEIGHTS.keys())
+        for i in range(len(placements) - 1):
+            w_higher = PLACEMENT_WEIGHTS[placements[i]]
+            w_lower = PLACEMENT_WEIGHTS[placements[i + 1]]
+            assert w_higher >= w_lower, (
+                f"Placement {placements[i]} weight ({w_higher}) should be >= "
+                f"placement {placements[i + 1]} weight ({w_lower})"
+            )
+
+    def test_default_lte_minimum_explicit(self):
+        """Default weight should be <= the smallest explicit weight."""
+        min_explicit = min(PLACEMENT_WEIGHTS.values())
+        assert PLACEMENT_WEIGHT_DEFAULT <= min_explicit
+
+
+class TestTierWeights:
+    def test_superset_of_thresholds_plus_rogue(self):
+        expected_keys = set(TIER_THRESHOLDS.keys()) | {"Rogue"}
+        assert expected_keys <= set(TIER_WEIGHTS.keys()), (
+            f"TIER_WEIGHTS keys {set(TIER_WEIGHTS.keys())} should be a superset of "
+            f"TIER_THRESHOLDS keys + Rogue: {expected_keys}"
+        )
+
+
+class TestFormatDates:
+    def test_dates_parseable(self):
+        """All format date fields should be valid ISO dates."""
+        date_fields = ["dataset_start", "dataset_end", "rotation_date"]
+        for slug, fmt in FORMATS.items():
+            for field in date_fields:
+                raw = fmt[field]
+                parsed = date.fromisoformat(raw)
+                assert isinstance(parsed, date), (
+                    f"FORMATS[{slug!r}][{field!r}] = {raw!r} is not a valid ISO date"
+                )
+
+    def test_date_ordering(self):
+        """dataset_start < dataset_end < rotation_date for each format."""
+        for slug, fmt in FORMATS.items():
+            start = date.fromisoformat(fmt["dataset_start"])
+            end = date.fromisoformat(fmt["dataset_end"])
+            rotation = date.fromisoformat(fmt["rotation_date"])
+            assert start < end, (
+                f"FORMATS[{slug!r}]: dataset_start ({start}) should be < dataset_end ({end})"
+            )
+            assert end < rotation, (
+                f"FORMATS[{slug!r}]: dataset_end ({end}) should be < rotation_date ({rotation})"
+            )
+
+
+class TestCoreThresholds:
+    def test_inclusion_rate_between_zero_and_one(self):
+        assert 0 < CORE_INCLUSION_RATE <= 1, (
+            f"CORE_INCLUSION_RATE should be in (0, 1], got {CORE_INCLUSION_RATE}"
+        )
+
+    def test_avg_copies_positive_integers(self):
+        for name, value in [
+            ("CORE_AVG_COPIES_POKEMON", CORE_AVG_COPIES_POKEMON),
+            ("CORE_AVG_COPIES_OTHER", CORE_AVG_COPIES_OTHER),
+        ]:
+            assert isinstance(value, int), f"{name} should be an int, got {type(value).__name__}"
+            assert value > 0, f"{name} should be positive, got {value}"

--- a/tests/test_data_contracts.py
+++ b/tests/test_data_contracts.py
@@ -119,35 +119,33 @@ class TestBuylistContract:
         buylist = json.loads((export_dir / "buylist.json").read_text())
 
         _assert_type(buylist, list, "buylist.json root")
-        if len(buylist) > 0:
-            for item in buylist:
-                _assert_keys(
-                    item,
-                    [
-                        "card_name",
-                        "card_id",
-                        "set_code",
-                        "set_number",
-                        "priority_score",
-                        "urgency",
-                        "core_flex",
-                        "archetypes",
-                        "avg_copies",
-                        "inclusion_rate",
-                    ],
-                    f"buylist item={item.get('card_name')}",
-                )
-                _assert_type(item["priority_score"], (int, float), "priority_score")
-                _assert_type(item["card_name"], str, "card_name")
-                _assert_type(item["archetypes"], list, "archetypes")
-                _assert_type(item["avg_copies"], (int, float), "avg_copies")
-                _assert_type(item["inclusion_rate"], (int, float), "inclusion_rate")
-                assert item["urgency"] in {"URGENT", "HIGH", "MODERATE"}, (
-                    f"Invalid urgency: {item['urgency']}"
-                )
-                assert item["core_flex"] in {"core", "flex"}, (
-                    f"Invalid core_flex: {item['core_flex']}"
-                )
+        assert len(buylist) > 0, "buylist should not be empty with test fixture data"
+        for item in buylist:
+            _assert_keys(
+                item,
+                [
+                    "card_name",
+                    "card_id",
+                    "set_code",
+                    "set_number",
+                    "priority_score",
+                    "urgency",
+                    "core_flex",
+                    "archetypes",
+                    "avg_copies",
+                    "inclusion_rate",
+                ],
+                f"buylist item={item.get('card_name')}",
+            )
+            _assert_type(item["priority_score"], (int, float), "priority_score")
+            _assert_type(item["card_name"], str, "card_name")
+            _assert_type(item["archetypes"], list, "archetypes")
+            _assert_type(item["avg_copies"], (int, float), "avg_copies")
+            _assert_type(item["inclusion_rate"], (int, float), "inclusion_rate")
+            assert item["urgency"] in {"URGENT", "HIGH", "MODERATE"}, (
+                f"Invalid urgency: {item['urgency']}"
+            )
+            assert item["core_flex"] in {"core", "flex"}, f"Invalid core_flex: {item['core_flex']}"
 
 
 @pytest.mark.integration
@@ -173,6 +171,128 @@ class TestTrendsContract:
                 "trends card item",
             )
             _assert_type(card["delta"], (int, float), "delta")
+
+
+@pytest.mark.integration
+class TestTimelineContract:
+    def test_timeline_json_shape(self, export_dir):
+        timeline = json.loads((export_dir / "timeline.json").read_text())
+
+        _assert_type(timeline, dict, "timeline.json root")
+        _assert_keys(timeline, ["weeks", "archetype_order"], "timeline.json")
+        _assert_type(timeline["weeks"], list, "weeks")
+        _assert_type(timeline["archetype_order"], list, "archetype_order")
+        assert len(timeline["weeks"]) > 0, "weeks should not be empty with test fixture data"
+
+    def test_timeline_week_entry_shape(self, export_dir):
+        timeline = json.loads((export_dir / "timeline.json").read_text())
+
+        for week in timeline["weeks"]:
+            _assert_keys(
+                week,
+                ["week", "tournament_count", "deck_count", "archetypes"],
+                f"timeline week={week.get('week')}",
+            )
+            _assert_type(week["week"], str, "week")
+            _assert_type(week["tournament_count"], int, "tournament_count")
+            _assert_type(week["deck_count"], int, "deck_count")
+            _assert_type(week["archetypes"], dict, "archetypes")
+
+
+@pytest.mark.integration
+class TestCardAnalysisContract:
+    def test_card_analysis_json_shape(self, export_dir):
+        path = export_dir / "card-analysis.json"
+        if not path.exists():
+            pytest.skip("card-analysis.json not exported (insufficient data)")
+
+        data = json.loads(path.read_text())
+        _assert_type(data, dict, "card-analysis.json root")
+        _assert_keys(data, ["cards", "generated_at"], "card-analysis.json")
+        _assert_type(data["cards"], list, "cards")
+
+    def test_card_analysis_item_shape(self, export_dir):
+        path = export_dir / "card-analysis.json"
+        if not path.exists():
+            pytest.skip("card-analysis.json not exported (insufficient data)")
+
+        data = json.loads(path.read_text())
+        for card in data["cards"]:
+            _assert_keys(
+                card,
+                [
+                    "card_name",
+                    "max_delta",
+                    "category",
+                    "archetypes",
+                    "avg_delta",
+                    "archetype_count",
+                ],
+                f"card-analysis item={card.get('card_name')}",
+            )
+            _assert_type(card["card_name"], str, "card_name")
+            _assert_type(card["max_delta"], (int, float), "max_delta")
+            _assert_type(card["archetypes"], list, "archetypes")
+            _assert_type(card["archetype_count"], int, "archetype_count")
+
+
+@pytest.mark.integration
+class TestWinningEdgeContract:
+    def test_winning_edge_json_shape(self, export_dir):
+        data = json.loads((export_dir / "winning-edge.json").read_text())
+
+        _assert_type(data, list, "winning-edge.json root")
+
+    def test_winning_edge_item_shape(self, export_dir):
+        data = json.loads((export_dir / "winning-edge.json").read_text())
+
+        for item in data:
+            _assert_keys(
+                item,
+                ["card_name", "win_pct", "field_pct", "edge"],
+                f"winning-edge item={item.get('card_name')}",
+            )
+            _assert_type(item["card_name"], str, "card_name")
+            _assert_type(item["win_pct"], (int, float), "win_pct")
+            _assert_type(item["field_pct"], (int, float), "field_pct")
+            _assert_type(item["edge"], (int, float), "edge")
+
+
+@pytest.mark.integration
+class TestChampionsLeagueContract:
+    def test_champions_league_dir_exists(self, export_dir):
+        cl_dir = export_dir / "champions-league"
+        assert cl_dir.is_dir(), "champions-league/ directory should exist"
+
+    def test_champions_league_file_shape(self, export_dir):
+        cl_dir = export_dir / "champions-league"
+        cl_files = list(cl_dir.glob("*.json"))
+        assert len(cl_files) > 0, "Expected at least one CL division file"
+
+        for cl_file in cl_files:
+            data = json.loads(cl_file.read_text())
+            _assert_keys(
+                data,
+                ["event_id", "event_name", "division", "date", "archetype_summary", "placements"],
+                f"champions-league/{cl_file.name}",
+            )
+            _assert_type(data["placements"], list, "placements")
+            _assert_type(data["archetype_summary"], list, "archetype_summary")
+            _assert_type(data["division"], str, "division")
+
+    def test_champions_league_placement_shape(self, export_dir):
+        cl_dir = export_dir / "champions-league"
+        for cl_file in cl_dir.glob("*.json"):
+            data = json.loads(cl_file.read_text())
+            for p in data["placements"]:
+                _assert_keys(
+                    p,
+                    ["standing", "player_name", "region", "decklist"],
+                    f"champions-league/{cl_file.name} placement",
+                )
+                _assert_type(p["standing"], int, "standing")
+                _assert_type(p["player_name"], str, "player_name")
+                _assert_type(p["decklist"], list, "decklist")
 
 
 @pytest.mark.integration
@@ -306,10 +426,12 @@ class TestExportCompleteness:
         "winning-edge.json",
         "ace-specs.json",
         "timeline.json",
+        "card-analysis.json",
     ]
 
     EXPECTED_DIRS = [
         "archetypes",
+        "champions-league",
     ]
 
     def test_all_expected_files_exist(self, export_dir):

--- a/tests/test_limitless_transforms.py
+++ b/tests/test_limitless_transforms.py
@@ -1,0 +1,358 @@
+"""Tests for scraper/limitless.py — HTML transform and parsing functions.
+
+All tests use inline HTML string literals passed to BeautifulSoup.
+No HTTP mocking or fixture files are needed.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup, Tag
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scraper.limitless import (
+    _DECKLIST_LINE_RE,
+    LimitlessClient,
+    match_archetype_labels,
+)
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_tag(html: str, selector: str = "a") -> Tag:
+    """Parse an HTML fragment and return the first matching tag."""
+    soup = BeautifulSoup(html, "html.parser")
+    tag = soup.find(selector)
+    assert tag is not None, f"No <{selector}> found in fragment"
+    return tag
+
+
+# ---------------------------------------------------------------------------
+# Sprite / archetype extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractArchetypeAndSprites:
+    """Tests for LimitlessClient._extract_archetype_and_sprites (static method)."""
+
+    def test_img_with_alt_text(self):
+        """img tag with alt text produces the correct archetype name and sprite URL."""
+        html = """
+        <a href="/decks/list/12345">
+            <img src="https://r2.limitlesstcg.net/pokemon/gen9/charizard.png"
+                 alt="Charizard" />
+        </a>
+        """
+        tag = _make_tag(html)
+        archetype, sprite_urls = LimitlessClient._extract_archetype_and_sprites(tag)
+
+        assert archetype == "Charizard"
+        assert sprite_urls == ["https://r2.limitlesstcg.net/pokemon/gen9/charizard.png"]
+
+    def test_img_without_alt_parses_filename(self):
+        """img tag without alt text falls back to parsing the filename from src."""
+        html = """
+        <a href="/decks/list/12345">
+            <img src="https://r2.limitlesstcg.net/pokemon/gen9/dragapult.png" />
+        </a>
+        """
+        tag = _make_tag(html)
+        archetype, sprite_urls = LimitlessClient._extract_archetype_and_sprites(tag)
+
+        assert archetype == "Dragapult"
+        assert len(sprite_urls) == 1
+
+    def test_empty_link_no_sprites(self):
+        """A link with no img children returns empty archetype and empty sprite list."""
+        html = '<a href="/decks/list/99999">Some Text</a>'
+        tag = _make_tag(html)
+        archetype, sprite_urls = LimitlessClient._extract_archetype_and_sprites(tag)
+
+        assert archetype == ""
+        assert sprite_urls == []
+
+    def test_multiple_sprites_joined(self):
+        """Multiple img tags produce a slash-separated archetype and ordered sprite list."""
+        html = """
+        <a href="/decks/list/12345">
+            <img src="https://r2.limitlesstcg.net/pokemon/gen9/charizard.png"
+                 alt="Charizard" />
+            <img src="https://r2.limitlesstcg.net/pokemon/gen9/pidgeot.png"
+                 alt="Pidgeot" />
+        </a>
+        """
+        tag = _make_tag(html)
+        archetype, sprite_urls = LimitlessClient._extract_archetype_and_sprites(tag)
+
+        assert archetype == "Charizard / Pidgeot"
+        assert len(sprite_urls) == 2
+        assert "charizard.png" in sprite_urls[0]
+        assert "pidgeot.png" in sprite_urls[1]
+
+    def test_filename_with_underscores(self):
+        """Underscores and hyphens in filenames are converted to spaces and title-cased."""
+        html = """
+        <a href="/decks/list/1">
+            <img src="https://r2.limitlesstcg.net/pokemon/gen9/iron_hands.png" />
+        </a>
+        """
+        tag = _make_tag(html)
+        archetype, _ = LimitlessClient._extract_archetype_and_sprites(tag)
+
+        assert archetype == "Iron Hands"
+
+
+# ---------------------------------------------------------------------------
+# Decklist line regex
+# ---------------------------------------------------------------------------
+
+
+class TestDecklistLineRegex:
+    """Tests for the _DECKLIST_LINE_RE pattern used in text-format decklist parsing."""
+
+    def test_standard_card_line(self):
+        match = _DECKLIST_LINE_RE.match("4 Dragapult ex SV6 86")
+        assert match is not None
+        assert match.group(1) == "4"
+        assert match.group(2) == "Dragapult ex"
+        assert match.group(3) == "SV6"
+        assert match.group(4) == "86"
+
+    def test_energy_line(self):
+        match = _DECKLIST_LINE_RE.match("8 Psychic Energy Energy PSY1")
+        assert match is not None
+        assert match.group(1) == "8"
+        assert match.group(3) == "Energy"
+
+    def test_non_card_line_no_match(self):
+        assert _DECKLIST_LINE_RE.match("Pokemon: 12") is None
+        assert _DECKLIST_LINE_RE.match("") is None
+
+
+# ---------------------------------------------------------------------------
+# Decklist parsing (card-link strategy)
+# ---------------------------------------------------------------------------
+
+
+class TestDecklistParsingCardLinks:
+    """Tests for the card-link HTML parsing strategy inside fetch_decklist.
+
+    Since fetch_decklist wraps HTTP + parsing, we test the parsing logic by
+    patching _soup to return a pre-built BeautifulSoup tree.
+    """
+
+    def _make_client_with_soup(self, html: str) -> LimitlessClient:
+        """Create a client whose _soup returns a fixed BeautifulSoup tree."""
+        soup = BeautifulSoup(html, "html.parser")
+        client = LimitlessClient.__new__(LimitlessClient)
+        client._base_url = "https://limitlesstcg.com"
+        client._soup = lambda url: soup
+        return client
+
+    def test_card_link_format(self):
+        """Card-link HTML elements are parsed into structured card dicts."""
+        html = """
+        <div>
+            <a class="card-link" href="/cards/SV6/86?translate=en">
+                <span class="card-count">4</span>
+                <span class="card-name">Dragapult ex</span>
+            </a>
+            <a class="card-link" href="/cards/SV5/23">
+                <span class="card-count">2</span>
+                <span class="card-name">Pidgeot ex</span>
+            </a>
+        </div>
+        """
+        client = self._make_client_with_soup(html)
+        result = client.fetch_decklist("https://limitlesstcg.com/decks/list/1")
+
+        assert result is not None
+        assert len(result.cards) == 2
+        assert result.cards[0]["count"] == 4
+        assert result.cards[0]["name"] == "Dragapult ex"
+        assert result.cards[0]["set_code"] == "SV6"
+        assert result.cards[0]["card_number"] == "86"
+        assert result.cards[0]["card_id"] == "SV6-86"
+
+    def test_text_format_fallback(self):
+        """When no card-link elements exist, the text-format regex is used."""
+        html = """
+        <div>
+            <pre>
+4 Dragapult ex SV6 86
+2 Pidgeot ex SV5 23
+            </pre>
+        </div>
+        """
+        client = self._make_client_with_soup(html)
+        result = client.fetch_decklist("https://limitlesstcg.com/decks/list/2")
+
+        assert result is not None
+        assert len(result.cards) == 2
+        assert result.cards[0]["name"] == "Dragapult ex"
+        assert result.cards[1]["name"] == "Pidgeot ex"
+
+    def test_basic_energy_text_format(self):
+        """Basic energy lines without set codes are parsed via the energy regex."""
+        html = """
+        <div>
+            <pre>
+8 Basic Psychic Energy
+4 Basic Fire Energy
+            </pre>
+        </div>
+        """
+        client = self._make_client_with_soup(html)
+        result = client.fetch_decklist("https://limitlesstcg.com/decks/list/3")
+
+        assert result is not None
+        assert len(result.cards) == 2
+        assert result.cards[0]["name"] == "Basic Psychic Energy"
+        assert result.cards[0]["set_code"] == "Energy"
+        assert result.cards[0]["count"] == 8
+        assert result.cards[1]["count"] == 4
+
+    def test_empty_decklist_returns_none(self):
+        """A page with no parseable cards returns None."""
+        html = "<div><p>No decklist available.</p></div>"
+        client = self._make_client_with_soup(html)
+        result = client.fetch_decklist("https://limitlesstcg.com/decks/list/999")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Standings row parsing
+# ---------------------------------------------------------------------------
+
+
+class TestStandingsRowParsing:
+    """Tests for placement parsing inside fetch_jp_city_league_placements.
+
+    We patch _soup to return a pre-built standings table, and mock
+    normalize_archetype to isolate the HTML parsing from archetype logic.
+    """
+
+    def _make_client_with_soup(self, html: str) -> LimitlessClient:
+        soup = BeautifulSoup(html, "html.parser")
+        client = LimitlessClient.__new__(LimitlessClient)
+        client._base_url = "https://limitlesstcg.com"
+        client._soup = lambda url: soup
+        return client
+
+    @patch(
+        "scraper.limitless.normalize_archetype",
+        side_effect=lambda urls, html_archetype="": html_archetype or "Unknown",
+    )
+    def test_standard_placement_row(self, mock_norm):
+        """A standard 4-column row extracts rank, player, archetype, and decklist URL."""
+        html = """
+        <table class="striped">
+            <tr><th>#</th><th>Player</th><th>Deck</th><th>List</th></tr>
+            <tr>
+                <td>1.</td>
+                <td>Satoshi</td>
+                <td>
+                    <a href="/decks/list/100">
+                        <img src="https://r2.limitlesstcg.net/pokemon/gen9/charizard.png"
+                             alt="Charizard" />
+                    </a>
+                </td>
+                <td><a href="/decks/list/100">View</a></td>
+            </tr>
+        </table>
+        """
+        client = self._make_client_with_soup(html)
+        placements = client.fetch_jp_city_league_placements(
+            "https://limitlesstcg.com/tournaments/jp/1234"
+        )
+
+        assert len(placements) == 1
+        p = placements[0]
+        assert p.placement == 1
+        assert p.player_name == "Satoshi"
+        assert p.decklist_url == "https://limitlesstcg.com/decks/list/100"
+        assert len(p.sprite_urls) == 1
+
+    @patch(
+        "scraper.limitless.normalize_archetype",
+        side_effect=lambda urls, html_archetype="": html_archetype or "Unknown",
+    )
+    def test_missing_decklist_url(self, mock_norm):
+        """A row without a decklist link sets decklist_url to None."""
+        html = """
+        <table class="striped">
+            <tr><th>#</th><th>Player</th><th>Deck</th></tr>
+            <tr>
+                <td>2.</td>
+                <td>Kasumi</td>
+                <td>Lugia VSTAR</td>
+            </tr>
+        </table>
+        """
+        client = self._make_client_with_soup(html)
+        placements = client.fetch_jp_city_league_placements(
+            "https://limitlesstcg.com/tournaments/jp/1234"
+        )
+
+        assert len(placements) == 1
+        p = placements[0]
+        assert p.placement == 2
+        assert p.player_name == "Kasumi"
+        assert p.decklist_url is None
+
+    @patch(
+        "scraper.limitless.normalize_archetype",
+        side_effect=lambda urls, html_archetype="": html_archetype or "Unknown",
+    )
+    def test_archetype_fallback_plain_text(self, mock_norm):
+        """When no sprites are present, cells[2] text is used as the archetype fallback."""
+        html = """
+        <table class="striped">
+            <tr><th>#</th><th>Player</th><th>Deck</th></tr>
+            <tr>
+                <td>3.</td>
+                <td>Takeshi</td>
+                <td>Gardevoir ex</td>
+            </tr>
+        </table>
+        """
+        client = self._make_client_with_soup(html)
+        placements = client.fetch_jp_city_league_placements(
+            "https://limitlesstcg.com/tournaments/jp/1234"
+        )
+
+        assert len(placements) == 1
+        # normalize_archetype is called with empty sprite_urls and html_archetype="Gardevoir ex"
+        mock_norm.assert_called_once_with([], html_archetype="Gardevoir ex")
+
+
+# ---------------------------------------------------------------------------
+# match_archetype_labels (pure function, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchArchetypeLabels:
+    def test_matching_by_date_and_standing(self):
+        jp = [
+            {"date": "2026-01-15", "standing": 1, "player_name": "A"},
+            {"date": "2026-01-15", "standing": 2, "player_name": "B"},
+        ]
+        limitless = [
+            {"date": "2026-01-15", "standing": 1, "archetype": "Charizard ex"},
+        ]
+        result = match_archetype_labels(jp, limitless)
+
+        assert result[0]["archetype"] == "Charizard ex"
+        assert result[1]["archetype"] == "Unknown"
+
+    def test_preserves_existing_archetype_when_no_match(self):
+        jp = [{"date": "2026-01-15", "standing": 1, "archetype": "Lugia VSTAR"}]
+        limitless = []
+        result = match_archetype_labels(jp, limitless)
+
+        assert result[0]["archetype"] == "Lugia VSTAR"

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,291 @@
+"""Tests for JP-to-EN translation functions in reports/json_export.py."""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from analysis.card_stats import EN_CARD_ALIASES, build_jp_en_lookup
+from db import SCHEMA
+from reports.json_export import (
+    _JP_RE,
+    JP_CARD_NAMES,
+    _build_jp_en_lookup,
+    _normalize_card_name,
+    _translate_all_json,
+    _translate_card_names,
+)
+
+# ---------------------------------------------------------------------------
+# _normalize_card_name
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCardName:
+    def test_known_alias_resolves(self) -> None:
+        """A name present in EN_CARD_ALIASES maps to its canonical form."""
+        assert _normalize_card_name("Lillie's Resolve") == "Lillie's Determination"
+        assert _normalize_card_name("Power Protein") == "Premium Power Pro"
+
+    def test_unknown_name_passes_through(self) -> None:
+        """A name not in EN_CARD_ALIASES is returned unchanged."""
+        assert _normalize_card_name("Nest Ball") == "Nest Ball"
+        assert _normalize_card_name("Charizard ex") == "Charizard ex"
+
+    def test_all_aliases_are_resolved(self) -> None:
+        """Every key in EN_CARD_ALIASES produces its corresponding value."""
+        for alias, canonical in EN_CARD_ALIASES.items():
+            assert _normalize_card_name(alias) == canonical
+
+
+# ---------------------------------------------------------------------------
+# _JP_RE regex
+# ---------------------------------------------------------------------------
+
+
+class TestJpRegex:
+    def test_matches_katakana(self) -> None:
+        assert _JP_RE.search("リザードンex") is not None
+
+    def test_matches_kanji(self) -> None:
+        assert _JP_RE.search("謎のカード") is not None
+
+    def test_no_match_on_english(self) -> None:
+        assert _JP_RE.search("Charizard ex") is None
+
+    def test_no_match_on_empty(self) -> None:
+        assert _JP_RE.search("") is None
+
+
+# ---------------------------------------------------------------------------
+# _build_jp_en_lookup (thin wrapper) and build_jp_en_lookup (shared builder)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildJpEnLookup:
+    def test_cards_table_entries(self, db: sqlite3.Connection) -> None:
+        """Lookup includes JP->EN pairs from the cards table."""
+        lookup = _build_jp_en_lookup(db)
+        assert lookup["リザードンex"] == "Charizard ex"
+        assert lookup["ドラパルトex"] == "Dragapult ex"
+        assert lookup["ふしぎなアメ"] == "Rare Candy"
+
+    def test_hardcoded_fallbacks_included(self, db: sqlite3.Connection) -> None:
+        """Lookup includes JP_CARD_NAMES fallback entries not in the DB."""
+        lookup = _build_jp_en_lookup(db)
+        # Pick a fallback entry that is NOT in the seed cards table
+        assert "イーブイ" in JP_CARD_NAMES, "Test assumption: Eevee is in JP_CARD_NAMES"
+        assert lookup["イーブイ"] == "Eevee"
+
+    def test_db_overrides_fallback(self) -> None:
+        """DB entries take priority over fallback dict."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(SCHEMA)
+        conn.execute(
+            "INSERT INTO cards (id, name_en, name_jp, set_code, image_url, supertype, rotation_legal) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("test-001", "DB Eevee", "イーブイ", "sv9", "https://img/test.png", "Pokemon", 1),
+        )
+        conn.commit()
+
+        lookup = build_jp_en_lookup(conn, fallback={"イーブイ": "Fallback Eevee"})
+        assert lookup["イーブイ"] == "DB Eevee"
+        conn.close()
+
+    def test_card_mappings_override_cards_table(self, db_integration: sqlite3.Connection) -> None:
+        """card_mappings entries override cards table entries."""
+        # db_integration has both cards table and card_mappings rows for リザードンex
+        lookup = build_jp_en_lookup(db_integration)
+        assert lookup["リザードンex"] == "Charizard ex"
+
+    def test_missing_card_mappings_table_handled(self) -> None:
+        """Gracefully handles missing card_mappings table."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        # Minimal schema: cards table only, no card_mappings
+        conn.execute(
+            "CREATE TABLE cards ("
+            "  id TEXT PRIMARY KEY, name_en TEXT, name_jp TEXT,"
+            "  set_code TEXT, image_url TEXT, supertype TEXT, rotation_legal INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO cards (id, name_en, name_jp, set_code, image_url, supertype, rotation_legal) "
+            "VALUES ('t1', 'Pikachu', 'ピカチュウ', 'sv1', 'https://img.png', 'Pokemon', 1)"
+        )
+        conn.commit()
+
+        lookup = build_jp_en_lookup(conn)
+        assert lookup["ピカチュウ"] == "Pikachu"
+        conn.close()
+
+    def test_empty_db_returns_fallback_only(self) -> None:
+        """Empty cards table still returns fallback entries."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(SCHEMA)
+        conn.commit()
+
+        fallback = {"テスト": "Test Card"}
+        lookup = build_jp_en_lookup(conn, fallback=fallback)
+        assert lookup["テスト"] == "Test Card"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _translate_card_names
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateCardNames:
+    """Tests for recursive JP card name translation in data structures."""
+
+    def setup_method(self) -> None:
+        self.lookup = {
+            "リザードンex": "Charizard ex",
+            "ドラパルトex": "Dragapult ex",
+        }
+
+    def test_translates_card_name_key(self) -> None:
+        data = {"card_name": "リザードンex", "count": 2}
+        result = _translate_card_names(data, self.lookup)
+        assert result["card_name"] == "Charizard ex"
+        assert result["card_name_jp"] == "リザードンex"
+        assert result["count"] == 2
+
+    def test_translates_card_key(self) -> None:
+        data = {"card": "ドラパルトex"}
+        result = _translate_card_names(data, self.lookup)
+        assert result["card"] == "Dragapult ex"
+        assert result["card_jp"] == "ドラパルトex"
+
+    def test_translates_card_a_and_card_b(self) -> None:
+        data = {"card_a": "リザードンex", "card_b": "ドラパルトex"}
+        result = _translate_card_names(data, self.lookup)
+        assert result["card_a"] == "Charizard ex"
+        assert result["card_b"] == "Dragapult ex"
+        assert result["card_a_jp"] == "リザードンex"
+        assert result["card_b_jp"] == "ドラパルトex"
+
+    def test_untranslatable_jp_name_unchanged(self) -> None:
+        """JP name not in lookup stays as-is, no _jp suffix key added."""
+        data = {"card_name": "謎のカード"}
+        result = _translate_card_names(data, self.lookup)
+        assert result["card_name"] == "謎のカード"
+        assert "card_name_jp" not in result
+
+    def test_english_name_unchanged(self) -> None:
+        """English card names are not touched (no JP chars detected)."""
+        data = {"card_name": "Nest Ball", "count": 4}
+        result = _translate_card_names(data, self.lookup)
+        assert result["card_name"] == "Nest Ball"
+        assert "card_name_jp" not in result
+
+    def test_non_card_key_with_jp_value_unchanged(self) -> None:
+        """Keys not in _CARD_NAME_KEYS are not translated even if value has JP chars."""
+        data = {"archetype": "リザードンex", "card_name": "リザードンex"}
+        result = _translate_card_names(data, self.lookup)
+        assert result["archetype"] == "リザードンex"
+        assert result["card_name"] == "Charizard ex"
+
+    def test_recursive_list(self) -> None:
+        data = [
+            {"card_name": "リザードンex"},
+            {"card_name": "ドラパルトex"},
+        ]
+        result = _translate_card_names(data, self.lookup)
+        assert result[0]["card_name"] == "Charizard ex"
+        assert result[1]["card_name"] == "Dragapult ex"
+
+    def test_nested_dicts(self) -> None:
+        data = {
+            "archetype": "test",
+            "cards": [{"card_name": "リザードンex", "count": 2}],
+        }
+        result = _translate_card_names(data, self.lookup)
+        assert result["cards"][0]["card_name"] == "Charizard ex"
+        assert result["cards"][0]["card_name_jp"] == "リザードンex"
+
+    def test_non_dict_non_list_passthrough(self) -> None:
+        """Scalar values pass through unchanged."""
+        assert _translate_card_names("hello", self.lookup) == "hello"
+        assert _translate_card_names(42, self.lookup) == 42
+        assert _translate_card_names(None, self.lookup) is None
+
+
+# ---------------------------------------------------------------------------
+# _translate_all_json (file-level translation)
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateAllJson:
+    """Tests for the file-walking JP translation post-pass."""
+
+    def setup_method(self) -> None:
+        self.lookup = {
+            "リザードンex": "Charizard ex",
+            "ふしぎなアメ": "Rare Candy",
+        }
+
+    def test_translates_json_with_jp_content(self, tmp_path: Path) -> None:
+        """JSON files containing JP card names get translated."""
+        data = [{"card_name": "リザードンex", "count": 2}]
+        json_file = tmp_path / "cards.json"
+        json_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+        _translate_all_json(tmp_path, self.lookup)
+
+        result = json.loads(json_file.read_text(encoding="utf-8"))
+        assert result[0]["card_name"] == "Charizard ex"
+        assert result[0]["card_name_jp"] == "リザードンex"
+
+    def test_skips_json_without_jp_content(self, tmp_path: Path) -> None:
+        """JSON files with only English content are not modified."""
+        data = [{"card_name": "Nest Ball", "count": 4}]
+        json_file = tmp_path / "english.json"
+        original = json.dumps(data, ensure_ascii=False, indent=2)
+        json_file.write_text(original, encoding="utf-8")
+
+        _translate_all_json(tmp_path, self.lookup)
+
+        # File should not be rewritten (content unchanged)
+        assert json_file.read_text(encoding="utf-8") == original
+
+    def test_handles_nested_subdirectories(self, tmp_path: Path) -> None:
+        """Recursively finds JSON in subdirectories."""
+        sub = tmp_path / "deep" / "nested"
+        sub.mkdir(parents=True)
+        data = {"cards": [{"card_name": "ふしぎなアメ"}]}
+        json_file = sub / "data.json"
+        json_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+        _translate_all_json(tmp_path, self.lookup)
+
+        result = json.loads(json_file.read_text(encoding="utf-8"))
+        assert result["cards"][0]["card_name"] == "Rare Candy"
+
+    def test_ignores_non_json_files(self, tmp_path: Path) -> None:
+        """Non-JSON files are not touched."""
+        txt_file = tmp_path / "notes.txt"
+        txt_file.write_text("リザードンex is cool", encoding="utf-8")
+
+        _translate_all_json(tmp_path, self.lookup)
+
+        assert txt_file.read_text(encoding="utf-8") == "リザードンex is cool"
+
+    def test_handles_invalid_json_gracefully(self, tmp_path: Path) -> None:
+        """Malformed JSON files log an error but do not raise."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{リザードンex: broken}", encoding="utf-8")
+
+        # Should not raise
+        _translate_all_json(tmp_path, self.lookup)
+
+        # File content unchanged (write was skipped)
+        assert bad_file.read_text(encoding="utf-8") == "{リザードンex: broken}"
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        """No error on empty directory."""
+        _translate_all_json(tmp_path, self.lookup)

--- a/web/app/[format]/__tests__/dashboard-client.test.tsx
+++ b/web/app/[format]/__tests__/dashboard-client.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { DashboardClient } from "../dashboard-client";
+import type {
+  MetaData,
+  TrendsData,
+  WinningEdgeCard,
+  AceSpec,
+  ArchetypeSummary,
+} from "@/app/lib/types";
+
+// --- Mocks ---
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/components/date-filter-provider", () => ({
+  useDateFilter: () => ({
+    activeWindow: "all" as const,
+    customRange: undefined,
+    setWindow: vi.fn(),
+  }),
+  fetchWindowedData: vi.fn(),
+}));
+
+vi.mock("@/app/components/date-filter", () => ({
+  DateFilter: () => <div data-testid="date-filter">DateFilter</div>,
+}));
+
+vi.mock("@/app/components/welcome-guide", () => ({
+  WelcomeGuide: () => <div data-testid="welcome-guide">WelcomeGuide</div>,
+}));
+
+vi.mock("@/app/components/meta-timeline", () => ({
+  MetaTimeline: () => <div data-testid="meta-timeline">MetaTimeline</div>,
+}));
+
+vi.mock("@/app/components/stat-card", () => ({
+  StatCard: ({ label, value }: { label: string; value: string }) => (
+    <div data-testid="stat-card">
+      {label}: {value}
+    </div>
+  ),
+}));
+
+vi.mock("@/app/components/tier-badge", () => ({
+  TierBadge: ({ tier }: { tier: string }) => (
+    <span data-testid="tier-badge">{tier}</span>
+  ),
+}));
+
+vi.mock("@/app/components/tooltip", () => ({
+  InfoIcon: () => <span data-testid="info-icon" />,
+}));
+
+// --- Test Data ---
+
+function makeArchetype(overrides: Partial<ArchetypeSummary>): ArchetypeSummary {
+  return {
+    archetype: "Unknown Deck",
+    slug: "unknown-deck",
+    meta_share: 5.0,
+    deck_count: 20,
+    best_placement: 1,
+    tier: "B",
+    ...overrides,
+  };
+}
+
+const sArchetype = makeArchetype({
+  archetype: "Dragapult ex",
+  slug: "dragapult-ex",
+  meta_share: 12.5,
+  deck_count: 150,
+  tier: "S",
+});
+
+const aArchetype = makeArchetype({
+  archetype: "Charizard Pidgeot",
+  slug: "charizard-pidgeot",
+  meta_share: 8.3,
+  deck_count: 95,
+  tier: "A",
+});
+
+const bArchetype = makeArchetype({
+  archetype: "Raging Bolt",
+  slug: "raging-bolt",
+  meta_share: 4.1,
+  deck_count: 45,
+  tier: "B",
+});
+
+const rogueArchetype = makeArchetype({
+  archetype: "Banette ex",
+  slug: "banette-ex",
+  meta_share: 0.5,
+  deck_count: 5,
+  tier: "Rogue",
+});
+
+const baseMeta: MetaData = {
+  generated_at: "2026-03-24T00:00:00Z",
+  tournament_count: 430,
+  deck_count: 5000,
+  date_range: { start: "2025-10-01", end: "2026-03-23" },
+  rotation_date: "2026-07-01",
+  tier_thresholds: { S: 10, A: 5, B: 2 },
+  archetypes: [sArchetype, aArchetype, bArchetype, rogueArchetype],
+  format: { slug: "ninja-spinner", name: "Ninja Spinner", name_en: "Ninja Spinner" },
+};
+
+const baseTrends: TrendsData = {
+  midpoint: "2026-02-15",
+  early_decks: 2000,
+  late_decks: 3000,
+  surging: [
+    { card_name: "Night Stretcher", early_count: 100, late_count: 300, early_pct: 5, late_pct: 10, delta: 5.0 },
+    { card_name: "Buddy-Buddy Poffin", early_count: 200, late_count: 500, early_pct: 10, late_pct: 16.7, delta: 6.7 },
+  ],
+  declining: [
+    { card_name: "Nest Ball", early_count: 400, late_count: 200, early_pct: 20, late_pct: 6.7, delta: -13.3 },
+  ],
+};
+
+const baseWinningEdge: WinningEdgeCard[] = [
+  { card_name: "Prime Catcher", field_pct: 30, win_pct: 55, edge: 25.0, winner_decks: 50, field_decks: 500 },
+];
+
+const baseAceSpecs: AceSpec[] = [
+  { card_name: "Hero's Cape", deck_count: 800, usage_pct: 16.0 },
+  { card_name: "Prime Catcher", deck_count: 600, usage_pct: 12.0 },
+];
+
+// --- Tests ---
+
+describe("DashboardClient", () => {
+  afterEach(cleanup);
+
+  function renderDashboard(overrides: Partial<Parameters<typeof DashboardClient>[0]> = {}) {
+    return render(
+      <DashboardClient
+        format="ninja-spinner"
+        meta={baseMeta}
+        trends={baseTrends}
+        winningEdge={baseWinningEdge}
+        aceSpecs={baseAceSpecs}
+        {...overrides}
+      />,
+    );
+  }
+
+  it("renders tier sections with S, A, and B archetypes", () => {
+    renderDashboard();
+    const tierSection = screen.getByTestId("tier-section");
+    expect(tierSection).toBeInTheDocument();
+
+    const tierBadges = screen.getAllByTestId("tier-badge");
+    const tierTexts = tierBadges.map((el) => el.textContent);
+    expect(tierTexts).toContain("S");
+    expect(tierTexts).toContain("A");
+    expect(tierTexts).toContain("B");
+  });
+
+  it("excludes Rogue-tier archetypes from the tier list preview", () => {
+    renderDashboard();
+    expect(screen.queryByText("Banette ex")).not.toBeInTheDocument();
+  });
+
+  it("displays archetype names in the tier list", () => {
+    renderDashboard();
+    expect(screen.getByText("Dragapult ex")).toBeInTheDocument();
+    expect(screen.getByText("Charizard Pidgeot")).toBeInTheDocument();
+    expect(screen.getByText("Raging Bolt")).toBeInTheDocument();
+  });
+
+  it("displays meta share percentages", () => {
+    renderDashboard();
+    const shares = screen.getAllByTestId("meta-share");
+    const shareTexts = shares.map((el) => el.textContent);
+    expect(shareTexts).toContain("12.5%");
+    expect(shareTexts).toContain("8.3%");
+    expect(shareTexts).toContain("4.1%");
+  });
+
+  it("renders archetype links pointing to detail pages", () => {
+    renderDashboard();
+    const links = screen.getAllByTestId("archetype-link");
+    const hrefs = links.map((el) => el.getAttribute("href"));
+    expect(hrefs).toContain("/ninja-spinner/archetypes/dragapult-ex");
+    expect(hrefs).toContain("/ninja-spinner/archetypes/charizard-pidgeot");
+    expect(hrefs).toContain("/ninja-spinner/archetypes/raging-bolt");
+  });
+
+  it("displays deck counts for archetypes", () => {
+    renderDashboard();
+    expect(screen.getByText("150")).toBeInTheDocument();
+    expect(screen.getByText("95")).toBeInTheDocument();
+    expect(screen.getByText("45")).toBeInTheDocument();
+  });
+
+  it("shows empty tier list when no S/A/B archetypes exist", () => {
+    const emptyMeta: MetaData = {
+      ...baseMeta,
+      archetypes: [rogueArchetype],
+    };
+    renderDashboard({ meta: emptyMeta });
+
+    const tierSection = screen.getByTestId("tier-section");
+    expect(tierSection).toBeInTheDocument();
+    // Table exists but has no archetype rows
+    expect(screen.queryAllByTestId("archetype-link")).toHaveLength(0);
+  });
+
+  it("renders surging and declining card names in the insights grid", () => {
+    renderDashboard();
+    expect(screen.getByText("Night Stretcher")).toBeInTheDocument();
+    expect(screen.getByText("Buddy-Buddy Poffin")).toBeInTheDocument();
+    expect(screen.getByText("Nest Ball")).toBeInTheDocument();
+  });
+
+  it("renders tournament count and deck count stats", () => {
+    renderDashboard();
+    expect(screen.getByText("430")).toBeInTheDocument();
+    expect(screen.getByText("5,000")).toBeInTheDocument();
+  });
+});

--- a/web/app/[format]/archetypes/__tests__/archetypes-client.test.tsx
+++ b/web/app/[format]/archetypes/__tests__/archetypes-client.test.tsx
@@ -1,0 +1,266 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ArchetypesClient } from "../archetypes-client";
+import type { ArchetypeSummary } from "@/app/lib/types";
+
+// --- Mocks ---
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/components/date-filter-provider", () => ({
+  useDateFilter: () => ({
+    activeWindow: "all" as const,
+    customRange: undefined,
+    setWindow: vi.fn(),
+  }),
+  fetchWindowedData: vi.fn(),
+}));
+
+vi.mock("@/app/components/date-filter", () => ({
+  DateFilter: () => <div data-testid="date-filter">DateFilter</div>,
+}));
+
+vi.mock("@/app/components/tier-badge", () => ({
+  TierBadge: ({ tier }: { tier: string }) => (
+    <span data-testid="tier-badge">{tier}</span>
+  ),
+}));
+
+vi.mock("@/app/components/sprite-row", () => ({
+  SpriteRow: ({ filenames }: { filenames: string[] }) => (
+    <span data-testid="sprite-row">{filenames.join(",")}</span>
+  ),
+}));
+
+vi.mock("@/app/components/meta-bar-chart", () => ({
+  MetaBarChart: () => <div data-testid="meta-bar-chart">MetaBarChart</div>,
+}));
+
+vi.mock("@/app/components/archetype-heat-matrix", () => ({
+  ArchetypeHeatMatrix: () => <div data-testid="archetype-heat-matrix" />,
+}));
+
+vi.mock("@/app/components/matchup-heat-matrix", () => ({
+  MatchupHeatMatrix: () => <div data-testid="matchup-heat-matrix" />,
+}));
+
+vi.mock("@/app/components/tooltip", () => ({
+  InfoIcon: () => <span data-testid="info-icon" />,
+}));
+
+// --- Test Data ---
+
+function makeArchetype(overrides: Partial<ArchetypeSummary>): ArchetypeSummary {
+  return {
+    archetype: "Unknown Deck",
+    slug: "unknown-deck",
+    meta_share: 5.0,
+    deck_count: 20,
+    best_placement: 1,
+    tier: "B",
+    ...overrides,
+  };
+}
+
+const mockArchetypes: ArchetypeSummary[] = [
+  makeArchetype({
+    archetype: "Charizard Pidgeot",
+    slug: "charizard-pidgeot",
+    meta_share: 18.5,
+    weighted_share: 22.3,
+    deck_count: 150,
+    best_placement: 1,
+    tier: "S",
+    sprite_filenames: ["charizard.png", "pidgeot.png"],
+    trend: "up",
+    trend_delta: 3.2,
+  }),
+  makeArchetype({
+    archetype: "Dragapult Dusknoir",
+    slug: "dragapult-dusknoir",
+    meta_share: 12.0,
+    weighted_share: 14.1,
+    deck_count: 95,
+    best_placement: 1,
+    tier: "A",
+    sprite_filenames: ["dragapult.png", "dusknoir.png"],
+    trend: "stable",
+  }),
+  makeArchetype({
+    archetype: "Raging Bolt",
+    slug: "raging-bolt",
+    meta_share: 6.0,
+    deck_count: 40,
+    best_placement: 3,
+    tier: "B",
+    sprite_filenames: ["raging-bolt.png"],
+    trend: "down",
+    trend_delta: -1.5,
+  }),
+  makeArchetype({
+    archetype: "Lugia Archeops",
+    slug: "lugia-archeops",
+    meta_share: 3.0,
+    deck_count: 18,
+    best_placement: 9,
+    tier: "C",
+    trend: "new",
+  }),
+  makeArchetype({
+    archetype: "Iron Thorns",
+    slug: "iron-thorns",
+    meta_share: 1.2,
+    deck_count: 8,
+    best_placement: 17,
+    tier: "Rogue",
+  }),
+];
+
+const defaultDateRange = { start: "2026-01-01", end: "2026-03-24" };
+
+function renderClient(archetypes: ArchetypeSummary[] = mockArchetypes) {
+  return render(
+    <ArchetypesClient
+      archetypes={archetypes}
+      format="ninja-spinner"
+      dateRange={defaultDateRange}
+    />,
+  );
+}
+
+// --- Tests ---
+
+describe("ArchetypesClient", () => {
+  afterEach(cleanup);
+
+  it("renders page title", () => {
+    renderClient();
+    expect(screen.getByText("Archetypes")).toBeInTheDocument();
+  });
+
+  it("shows archetype count and total decklists", () => {
+    renderClient();
+    expect(
+      screen.getByText(/5 archetypes across 311 decklists/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders archetype names", () => {
+    renderClient();
+    expect(screen.getByText("Charizard Pidgeot")).toBeInTheDocument();
+    expect(screen.getByText("Dragapult Dusknoir")).toBeInTheDocument();
+    expect(screen.getByText("Raging Bolt")).toBeInTheDocument();
+    expect(screen.getByText("Lugia Archeops")).toBeInTheDocument();
+    expect(screen.getByText("Iron Thorns")).toBeInTheDocument();
+  });
+
+  it("renders tier badges for each archetype", () => {
+    renderClient();
+    const badges = screen.getAllByTestId("tier-badge");
+    const tierTexts = badges.map((b) => b.textContent);
+    expect(tierTexts).toContain("S");
+    expect(tierTexts).toContain("A");
+    expect(tierTexts).toContain("B");
+    expect(tierTexts).toContain("C");
+    expect(tierTexts).toContain("Rogue");
+  });
+
+  it("displays meta share percentages", () => {
+    renderClient();
+    // Weighted share is displayed via formatPct; check the rendered text
+    // Charizard has weighted_share 22.3 and meta_share 18.5
+    expect(screen.getByText(/22\.3%/)).toBeInTheDocument();
+    expect(screen.getByText(/18\.5%/)).toBeInTheDocument();
+  });
+
+  it("displays deck counts", () => {
+    renderClient();
+    expect(screen.getByText("150")).toBeInTheDocument();
+    expect(screen.getByText("95")).toBeInTheDocument();
+    expect(screen.getByText("40")).toBeInTheDocument();
+  });
+
+  it("renders links to archetype detail pages", () => {
+    renderClient();
+    const link = screen.getByText("Charizard Pidgeot").closest("a");
+    expect(link).toHaveAttribute(
+      "href",
+      "/ninja-spinner/archetypes/charizard-pidgeot",
+    );
+  });
+
+  it("renders sprite rows for archetypes with sprites", () => {
+    renderClient();
+    const sprites = screen.getAllByTestId("sprite-row");
+    const spriteTexts = sprites.map((s) => s.textContent);
+    expect(spriteTexts).toContain("charizard.png,pidgeot.png");
+    expect(spriteTexts).toContain("dragapult.png,dusknoir.png");
+    expect(spriteTexts).toContain("raging-bolt.png");
+  });
+
+  it("renders empty sprite row for archetypes without sprites", () => {
+    renderClient();
+    const sprites = screen.getAllByTestId("sprite-row");
+    // Lugia Archeops and Iron Thorns have no sprite_filenames (defaults to [])
+    const emptySprites = sprites.filter((s) => s.textContent === "");
+    expect(emptySprites.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders MetaBarChart", () => {
+    renderClient();
+    expect(screen.getByTestId("meta-bar-chart")).toBeInTheDocument();
+  });
+
+  it("renders DateFilter", () => {
+    renderClient();
+    expect(screen.getByTestId("date-filter")).toBeInTheDocument();
+  });
+
+  it("shows All Archetypes tab with count", () => {
+    renderClient();
+    expect(screen.getByText("All Archetypes")).toBeInTheDocument();
+    // The tab shows the count as a separate span
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("renders guide link", () => {
+    renderClient();
+    const guideLink = screen.getByText(/How this works/);
+    expect(guideLink).toHaveAttribute(
+      "href",
+      "/ninja-spinner/guide#archetypes",
+    );
+  });
+
+  it("renders empty state with zero archetypes", () => {
+    renderClient([]);
+    expect(
+      screen.getByText(/0 archetypes across 0 decklists/),
+    ).toBeInTheDocument();
+    // Tab count shows 0
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("does not render matchups tab when no matchup data provided", () => {
+    renderClient();
+    expect(screen.queryByText("Matchups")).not.toBeInTheDocument();
+  });
+
+  it("does not render overlap tab when no overlap data provided", () => {
+    renderClient();
+    expect(screen.queryByText("Card Overlap")).not.toBeInTheDocument();
+  });
+});

--- a/web/app/[format]/buylist/__tests__/buylist-client.test.tsx
+++ b/web/app/[format]/buylist/__tests__/buylist-client.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BuylistClient } from "../buylist-client";
+import type { BuylistCard, StapleCard } from "@/app/lib/types";
+
+// --- Mocks ---
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ format: "ninja-spinner" }),
+}));
+
+vi.mock("@/app/components/date-filter-provider", () => ({
+  useDateFilter: () => ({
+    activeWindow: "all" as const,
+    customRange: undefined,
+    setWindow: vi.fn(),
+  }),
+  fetchWindowedData: vi.fn(),
+}));
+
+vi.mock("@/app/components/date-filter", () => ({
+  DateFilter: () => <div data-testid="date-filter">DateFilter</div>,
+}));
+
+vi.mock("lucide-react", () => ({
+  ExternalLink: () => <span data-testid="external-link-icon" />,
+  ArrowUpDown: () => <span data-testid="arrow-updown-icon" />,
+  Search: () => <span data-testid="search-icon" />,
+}));
+
+// --- Test Data ---
+
+function makeBuylistCard(overrides: Partial<BuylistCard>): BuylistCard {
+  return {
+    card_name: "Test Card",
+    card_id: null,
+    set_code: null,
+    set_number: null,
+    priority_score: 10.0,
+    urgency: "MODERATE",
+    core_flex: "core",
+    archetypes: ["Charizard ex"],
+    avg_copies: 2.5,
+    inclusion_rate: 0.85,
+    ...overrides,
+  };
+}
+
+function makeStapleCard(overrides: Partial<StapleCard>): StapleCard {
+  return {
+    card_name: "Staple Card",
+    deck_count: 100,
+    usage_pct: 75.0,
+    avg_copies: 3.0,
+    ...overrides,
+  };
+}
+
+const mockBuylist: BuylistCard[] = [
+  makeBuylistCard({
+    card_name: "Charizard ex",
+    priority_score: 25.3,
+    urgency: "URGENT",
+    core_flex: "core",
+    archetypes: ["Charizard ex", "Charizard Pidgeot"],
+    avg_copies: 3.0,
+    inclusion_rate: 0.95,
+  }),
+  makeBuylistCard({
+    card_name: "Rare Candy",
+    priority_score: 18.7,
+    urgency: "HIGH",
+    core_flex: "core",
+    archetypes: ["Charizard ex", "Gardevoir ex", "Mewtwo ex"],
+    avg_copies: 4.0,
+    inclusion_rate: 0.88,
+  }),
+  makeBuylistCard({
+    card_name: "Iono",
+    priority_score: 12.1,
+    urgency: "MODERATE",
+    core_flex: "flex",
+    archetypes: ["Dragapult ex"],
+    avg_copies: 2.0,
+    inclusion_rate: 0.60,
+  }),
+];
+
+const mockStaples: StapleCard[] = [
+  makeStapleCard({ card_name: "Boss's Orders", usage_pct: 92.0, avg_copies: 2.0, deck_count: 450 }),
+  makeStapleCard({ card_name: "Professor's Research", usage_pct: 88.5, avg_copies: 3.0, deck_count: 420 }),
+];
+
+const mockFlex: StapleCard[] = [
+  makeStapleCard({ card_name: "Switch", usage_pct: 45.0, avg_copies: 1.5, deck_count: 200 }),
+];
+
+const baseDateRange = { start: "2025-10-01", end: "2026-03-23" };
+
+// --- Tests ---
+
+describe("BuylistClient", () => {
+  afterEach(cleanup);
+
+  function renderBuylist(overrides: Partial<Parameters<typeof BuylistClient>[0]> = {}) {
+    return render(
+      <BuylistClient
+        buylist={mockBuylist}
+        staples={mockStaples}
+        flex={mockFlex}
+        dateRange={baseDateRange}
+        {...overrides}
+      />,
+    );
+  }
+
+  it("renders the page title", () => {
+    renderBuylist();
+    expect(screen.getByText("Buy List")).toBeInTheDocument();
+  });
+
+  it("renders card names from buylist data", () => {
+    renderBuylist();
+    expect(screen.getByText("Charizard ex")).toBeInTheDocument();
+    expect(screen.getByText("Rare Candy")).toBeInTheDocument();
+    expect(screen.getByText("Iono")).toBeInTheDocument();
+  });
+
+  it("displays priority scores", () => {
+    renderBuylist();
+    expect(screen.getByText("25.3")).toBeInTheDocument();
+    expect(screen.getByText("18.7")).toBeInTheDocument();
+    expect(screen.getByText("12.1")).toBeInTheDocument();
+  });
+
+  it("displays avg copies", () => {
+    renderBuylist();
+    expect(screen.getByText("3.0")).toBeInTheDocument();
+    expect(screen.getByText("4.0")).toBeInTheDocument();
+    expect(screen.getByText("2.0")).toBeInTheDocument();
+  });
+
+  it("displays inclusion rates as percentages", () => {
+    renderBuylist();
+    expect(screen.getByText("95.0%")).toBeInTheDocument();
+    expect(screen.getByText("88.0%")).toBeInTheDocument();
+    expect(screen.getByText("60.0%")).toBeInTheDocument();
+  });
+
+  it("displays archetype names for each card", () => {
+    renderBuylist();
+    // Charizard ex card shows first 2 archetypes
+    expect(screen.getByText(/Charizard Pidgeot/)).toBeInTheDocument();
+    // Rare Candy has 3 archetypes, shows first 2 + "+1"
+    expect(screen.getByText(/Gardevoir ex/)).toBeInTheDocument();
+    expect(screen.getByText(/\+1/)).toBeInTheDocument();
+  });
+
+  it("shows card count in subtitle", () => {
+    renderBuylist();
+    expect(screen.getByText(/3 cards across S\/A\/B tier archetypes/)).toBeInTheDocument();
+  });
+
+  it("renders the date filter", () => {
+    renderBuylist();
+    expect(screen.getByTestId("date-filter")).toBeInTheDocument();
+  });
+
+  it("renders a guide link", () => {
+    renderBuylist();
+    const guideLink = screen.getByText(/How this works/);
+    expect(guideLink).toBeInTheDocument();
+    expect(guideLink.closest("a")).toHaveAttribute("href", "/ninja-spinner/guide#buy-list");
+  });
+
+  it("shows tab counts for Full List, Staples, and Flex", () => {
+    renderBuylist();
+    const fullListTab = screen.getByRole("button", { name: /Full List/i });
+    const staplesTab = screen.getByRole("button", { name: /Staples/i });
+    const flexTab = screen.getByRole("button", { name: /Flex/i });
+
+    expect(fullListTab).toHaveTextContent("3");
+    expect(staplesTab).toHaveTextContent("2");
+    expect(flexTab).toHaveTextContent("1");
+  });
+
+  it("switches to Staples tab and shows staple cards", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    await user.click(screen.getByRole("button", { name: /Staples/i }));
+
+    expect(screen.getByText("Boss's Orders")).toBeInTheDocument();
+    expect(screen.getByText("Professor's Research")).toBeInTheDocument();
+    // Full List cards should not be visible
+    expect(screen.queryByText("Rare Candy")).not.toBeInTheDocument();
+  });
+
+  it("switches to Flex tab and shows flex cards", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    await user.click(screen.getByRole("button", { name: /Flex/i }));
+
+    expect(screen.getByText("Switch")).toBeInTheDocument();
+    // Full List cards should not be visible
+    expect(screen.queryByText("Rare Candy")).not.toBeInTheDocument();
+  });
+
+  it("shows staple usage percentages on Staples tab", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    await user.click(screen.getByRole("button", { name: /Staples/i }));
+
+    expect(screen.getByText("92.0%")).toBeInTheDocument();
+    expect(screen.getByText("88.5%")).toBeInTheDocument();
+  });
+
+  it("shows deck counts on Staples tab", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    await user.click(screen.getByRole("button", { name: /Staples/i }));
+
+    expect(screen.getByText("450")).toBeInTheDocument();
+    expect(screen.getByText("420")).toBeInTheDocument();
+  });
+
+  it("renders empty state when buylist is empty", () => {
+    renderBuylist({ buylist: [], staples: [], flex: [] });
+    expect(screen.getByText(/0 cards across S\/A\/B tier archetypes/)).toBeInTheDocument();
+    expect(screen.getByText("No results found")).toBeInTheDocument();
+  });
+
+  it("renders TCGPlayer links for each card", () => {
+    renderBuylist();
+    const links = screen.getAllByTestId("external-link-icon");
+    expect(links).toHaveLength(3);
+  });
+
+  it("sorts by priority score when column header is clicked", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    // Click Priority header to sort (default desc)
+    const priorityHeader = screen.getByText("Priority");
+    await user.click(priorityHeader);
+
+    const rows = screen.getAllByRole("row");
+    // Row 0 is header, data rows start at index 1
+    const firstDataRow = rows[1];
+    const lastDataRow = rows[rows.length - 1];
+
+    // Descending: highest priority first
+    expect(firstDataRow).toHaveTextContent("25.3");
+    expect(lastDataRow).toHaveTextContent("12.1");
+  });
+
+  it("sorts ascending on second click of priority header", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    const priorityHeader = screen.getByText("Priority");
+    // First click: desc
+    await user.click(priorityHeader);
+    // Second click: asc
+    await user.click(priorityHeader);
+
+    const rows = screen.getAllByRole("row");
+    const firstDataRow = rows[1];
+    const lastDataRow = rows[rows.length - 1];
+
+    // Ascending: lowest priority first
+    expect(firstDataRow).toHaveTextContent("12.1");
+    expect(lastDataRow).toHaveTextContent("25.3");
+  });
+
+  it("filters cards by search input", async () => {
+    const user = userEvent.setup();
+    renderBuylist();
+
+    const searchInput = screen.getByPlaceholderText("Search cards...");
+    await user.type(searchInput, "Rare");
+
+    expect(screen.getByText("Rare Candy")).toBeInTheDocument();
+    expect(screen.queryByText("Charizard ex")).not.toBeInTheDocument();
+    expect(screen.queryByText("Iono")).not.toBeInTheDocument();
+  });
+});

--- a/web/app/[format]/tournaments/__tests__/tournaments-client.test.tsx
+++ b/web/app/[format]/tournaments/__tests__/tournaments-client.test.tsx
@@ -1,0 +1,363 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { TournamentsClient } from "../tournaments-client";
+import type {
+  CityLeagueIndex,
+  CityLeagueTournament,
+} from "@/app/lib/types";
+
+// --- Mocks ---
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/components/date-filter-provider", () => ({
+  useDateFilter: () => ({
+    activeWindow: "all" as const,
+    customRange: undefined,
+    setWindow: vi.fn(),
+  }),
+  fetchWindowedData: vi.fn(),
+}));
+
+vi.mock("@/app/components/date-filter", () => ({
+  DateFilter: () => <div data-testid="date-filter">DateFilter</div>,
+}));
+
+vi.mock("@/app/components/sprite-row", () => ({
+  SpriteRow: ({ filenames }: { filenames: string[] }) => (
+    <span data-testid="sprite-row">{filenames.join(",")}</span>
+  ),
+}));
+
+vi.mock("@/app/components/tier-badge", () => ({
+  TierBadge: ({ tier }: { tier: string }) => (
+    <span data-testid="tier-badge">{tier}</span>
+  ),
+}));
+
+// --- Helpers ---
+
+function makeTournament(
+  overrides: Partial<CityLeagueTournament> = {},
+): CityLeagueTournament {
+  return {
+    id: "t-1",
+    name: "Tokyo City League",
+    date: "2026-03-20",
+    prefecture: "Tokyo",
+    player_count: 64,
+    source_url: "https://example.com/tournament/1",
+    top_finishers: [
+      {
+        standing: 1,
+        player_name: "Ash K.",
+        archetype: "Charizard Pidgeot",
+        slug: "charizard-pidgeot",
+        sprite_filenames: ["charizard.png", "pidgeot.png"],
+        tier: "S",
+      },
+      {
+        standing: 2,
+        player_name: "Misty W.",
+        archetype: "Dragapult Dusknoir",
+        slug: "dragapult-dusknoir",
+        sprite_filenames: ["dragapult.png"],
+        tier: "A",
+      },
+    ],
+    archetype_distribution: [
+      {
+        archetype: "Charizard Pidgeot",
+        slug: "charizard-pidgeot",
+        count: 10,
+        share: 0.156,
+        sprite_filenames: ["charizard.png"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeIndex(
+  tournaments: CityLeagueTournament[] = [makeTournament()],
+  overrides: Partial<CityLeagueIndex> = {},
+): CityLeagueIndex {
+  return {
+    generated_at: "2026-03-21T00:00:00Z",
+    tournament_count: tournaments.length,
+    deck_count: tournaments.reduce(
+      (sum, t) => sum + (t.player_count ?? 0),
+      0,
+    ),
+    date_range: { start: "2026-03-01", end: "2026-03-21" },
+    rising_archetypes: [],
+    recent_winners: [
+      {
+        archetype: "Charizard Pidgeot",
+        slug: "charizard-pidgeot",
+        sprite_filenames: ["charizard.png"],
+        date: "2026-03-20",
+        tournament_name: "Tokyo City League",
+        player_name: "Ash K.",
+      },
+    ],
+    tournaments,
+    ...overrides,
+  };
+}
+
+const defaultDateRange = { start: "2026-03-01", end: "2026-03-21" };
+
+// --- Tests ---
+
+describe("TournamentsClient", () => {
+  afterEach(cleanup);
+
+  it("renders tournament names", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("Tokyo City League")).toBeInTheDocument();
+  });
+
+  it("shows formatted dates in group headers", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("Mar 20, 2026")).toBeInTheDocument();
+  });
+
+  it("shows deck count in the header stats", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    // The deck count appears next to the "Decks" label
+    const decksLabel = screen.getByText("Decks");
+    const decksValue = decksLabel.parentElement?.querySelector(
+      ".font-mono",
+    );
+    expect(decksValue?.textContent).toBe("64");
+  });
+
+  it("shows tournament count in the header", () => {
+    const index = makeIndex([
+      makeTournament(),
+      makeTournament({ id: "t-2", name: "Osaka CL" }),
+    ]);
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={index}
+        dateRange={defaultDateRange}
+      />,
+    );
+    // The tournament count appears next to the "Tournaments" label
+    const tournamentsLabel = screen.getByText("Tournaments", {
+      selector: "span",
+    });
+    const tournamentsValue = tournamentsLabel.parentElement?.querySelector(
+      ".font-mono",
+    );
+    expect(tournamentsValue?.textContent).toBe("2");
+  });
+
+  it("renders table column headers", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Tournament")).toBeInTheDocument();
+    expect(screen.getByText("Prefecture")).toBeInTheDocument();
+    expect(screen.getByText("Players")).toBeInTheDocument();
+    expect(screen.getByText("Winner")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no tournaments", () => {
+    const emptyIndex = makeIndex([], {
+      tournament_count: 0,
+      deck_count: 0,
+      recent_winners: [],
+    });
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={emptyIndex}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(
+      screen.getByText("No tournaments found for this time window."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders multiple tournaments grouped by date", () => {
+    const tournaments = [
+      makeTournament({ id: "t-1", name: "Tokyo CL", date: "2026-03-20" }),
+      makeTournament({ id: "t-2", name: "Osaka CL", date: "2026-03-20" }),
+      makeTournament({ id: "t-3", name: "Nagoya CL", date: "2026-03-19" }),
+    ];
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex(tournaments)}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("Tokyo CL")).toBeInTheDocument();
+    expect(screen.getByText("Osaka CL")).toBeInTheDocument();
+    expect(screen.getByText("Nagoya CL")).toBeInTheDocument();
+    // Both date group headers should appear
+    expect(screen.getByText("Mar 20, 2026")).toBeInTheDocument();
+    expect(screen.getByText("Mar 19, 2026")).toBeInTheDocument();
+  });
+
+  it("shows group tournament count label", () => {
+    const tournaments = [
+      makeTournament({ id: "t-1", name: "Tokyo CL", date: "2026-03-20" }),
+      makeTournament({ id: "t-2", name: "Osaka CL", date: "2026-03-20" }),
+    ];
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex(tournaments)}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("2 tournaments")).toBeInTheDocument();
+  });
+
+  it("shows singular tournament label for single-tournament group", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("1 tournament")).toBeInTheDocument();
+  });
+
+  it("renders winner sprite row for tournaments", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    const spriteRows = screen.getAllByTestId("sprite-row");
+    expect(spriteRows.length).toBeGreaterThan(0);
+  });
+
+  it("displays player count placeholder when missing", () => {
+    const tournament = makeTournament({ player_count: null });
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex([tournament])}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("--")).toBeInTheDocument();
+  });
+
+  it("renders the page title and description", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Tournaments" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("City League results across Japan, sorted by date."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders latest winner link in header", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    const winnerLink = screen.getByRole("link", {
+      name: /Charizard Pidgeot/,
+    });
+    expect(winnerLink).toHaveAttribute(
+      "href",
+      "/ninja-spinner/archetypes/charizard-pidgeot",
+    );
+  });
+
+  it("renders rising archetypes when present", () => {
+    const index = makeIndex([], {
+      tournament_count: 0,
+      deck_count: 0,
+      recent_winners: [],
+      rising_archetypes: [
+        {
+          archetype: "Lugia Archeops",
+          slug: "lugia-archeops",
+          trend: "up",
+          trend_delta: 3.5,
+          sprite_filenames: ["lugia.png"],
+          tier: "A",
+        },
+      ],
+    });
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={index}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByText("Lugia Archeops")).toBeInTheDocument();
+    expect(screen.getByText("+3.5")).toBeInTheDocument();
+  });
+
+  it("renders the date filter component", () => {
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex()}
+        dateRange={defaultDateRange}
+      />,
+    );
+    expect(screen.getByTestId("date-filter")).toBeInTheDocument();
+  });
+});

--- a/web/app/[format]/trends/__tests__/trends-client.test.tsx
+++ b/web/app/[format]/trends/__tests__/trends-client.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { TrendsClient } from "../trends-client";
+import type { TrendsData, TrendCard, WinningEdgeCard } from "@/app/lib/types";
+
+// --- Mocks ---
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/app/components/date-filter-provider", () => ({
+  useDateFilter: () => ({
+    activeWindow: "all" as const,
+    customRange: undefined,
+    setWindow: vi.fn(),
+  }),
+  fetchWindowedData: vi.fn(),
+}));
+
+vi.mock("@/app/components/date-filter", () => ({
+  DateFilter: () => <div data-testid="date-filter">DateFilter</div>,
+}));
+
+vi.mock("recharts", () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div data-testid="bar" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="responsive-container">{children}</div>,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+vi.mock("lucide-react", () => ({
+  TrendingUp: () => <span data-testid="trending-up-icon" />,
+  TrendingDown: () => <span data-testid="trending-down-icon" />,
+  Trophy: () => <span data-testid="trophy-icon" />,
+}));
+
+// --- Test Data ---
+
+function makeTrendCard(overrides: Partial<TrendCard>): TrendCard {
+  return {
+    card_name: "Test Card",
+    early_count: 100,
+    late_count: 200,
+    early_pct: 5.0,
+    late_pct: 10.0,
+    delta: 5.0,
+    ...overrides,
+  };
+}
+
+const surgingCards: TrendCard[] = [
+  makeTrendCard({
+    card_name: "Night Stretcher",
+    early_pct: 5.0,
+    late_pct: 12.3,
+    delta: 7.3,
+    archetypes: [
+      { archetype: "Dragapult ex", early_pct: 10, late_pct: 20, delta: 10.0 },
+    ],
+  }),
+  makeTrendCard({
+    card_name: "Buddy-Buddy Poffin",
+    early_pct: 10.0,
+    late_pct: 16.7,
+    delta: 6.7,
+  }),
+];
+
+const decliningCards: TrendCard[] = [
+  makeTrendCard({
+    card_name: "Nest Ball",
+    early_pct: 20.0,
+    late_pct: 6.7,
+    delta: -13.3,
+  }),
+  makeTrendCard({
+    card_name: "Ultra Ball",
+    early_pct: 15.0,
+    late_pct: 11.2,
+    delta: -3.8,
+  }),
+];
+
+const baseTrends: TrendsData = {
+  midpoint: "2026-02-15",
+  early_decks: 2000,
+  late_decks: 3000,
+  surging: surgingCards,
+  declining: decliningCards,
+};
+
+const baseWinningEdge: WinningEdgeCard[] = [
+  { card_name: "Prime Catcher", field_pct: 30.0, win_pct: 55.0, edge: 25.0, winner_decks: 50, field_decks: 500 },
+];
+
+const baseDateRange = { start: "2025-10-01", end: "2026-03-23" };
+
+// --- Tests ---
+
+describe("TrendsClient", () => {
+  afterEach(cleanup);
+
+  function renderTrends(overrides: Partial<Parameters<typeof TrendsClient>[0]> = {}) {
+    return render(
+      <TrendsClient
+        trends={baseTrends}
+        winningEdge={baseWinningEdge}
+        format="ninja-spinner"
+        dateRange={baseDateRange}
+        {...overrides}
+      />,
+    );
+  }
+
+  it("renders the page title", () => {
+    renderTrends();
+    expect(screen.getByText("Trends")).toBeInTheDocument();
+  });
+
+  it("renders surging and declining section headers", () => {
+    renderTrends();
+    expect(screen.getByText("Surging Cards")).toBeInTheDocument();
+    expect(screen.getByText("Declining Cards")).toBeInTheDocument();
+  });
+
+  it("displays surging card names", () => {
+    renderTrends();
+    expect(screen.getByText("Night Stretcher")).toBeInTheDocument();
+    expect(screen.getByText("Buddy-Buddy Poffin")).toBeInTheDocument();
+  });
+
+  it("displays declining card names", () => {
+    renderTrends();
+    expect(screen.getByText("Nest Ball")).toBeInTheDocument();
+    expect(screen.getByText("Ultra Ball")).toBeInTheDocument();
+  });
+
+  it("shows delta percentages for surging cards", () => {
+    renderTrends();
+    expect(screen.getByText("+7.3%")).toBeInTheDocument();
+    expect(screen.getByText("+6.7%")).toBeInTheDocument();
+  });
+
+  it("shows delta percentages for declining cards", () => {
+    renderTrends();
+    expect(screen.getByText("-13.3%")).toBeInTheDocument();
+    expect(screen.getByText("-3.8%")).toBeInTheDocument();
+  });
+
+  it("shows early and late percentages in surging table", () => {
+    renderTrends();
+    expect(screen.getByText("5.0%")).toBeInTheDocument();
+    expect(screen.getByText("12.3%")).toBeInTheDocument();
+  });
+
+  it("renders the midpoint and deck counts in subtitle", () => {
+    renderTrends();
+    expect(screen.getByText(/2000 decks/)).toBeInTheDocument();
+    expect(screen.getByText(/3000 decks/)).toBeInTheDocument();
+    expect(screen.getByText(/2026-02-15/)).toBeInTheDocument();
+  });
+
+  it("renders a guide link", () => {
+    renderTrends();
+    const guideLink = screen.getByText(/How this works/);
+    expect(guideLink).toBeInTheDocument();
+    expect(guideLink.closest("a")).toHaveAttribute("href", "/ninja-spinner/guide#trends");
+  });
+
+  it("renders the winning edge section", () => {
+    renderTrends();
+    expect(screen.getByText(/Winning Edge/)).toBeInTheDocument();
+    expect(screen.getByText("Prime Catcher")).toBeInTheDocument();
+    expect(screen.getByText("55.0%")).toBeInTheDocument();
+    expect(screen.getByText("+25.0%")).toBeInTheDocument();
+  });
+
+  it("renders the bar chart", () => {
+    renderTrends();
+    expect(screen.getByTestId("responsive-container")).toBeInTheDocument();
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+  });
+
+  it("renders archetype breakdown for surging cards that have archetypes", () => {
+    renderTrends();
+    expect(screen.getByText("Dragapult ex")).toBeInTheDocument();
+    expect(screen.getByText("+10.0%")).toBeInTheDocument();
+  });
+
+  it("renders empty tables when surging is empty but declining has data", () => {
+    const trends: TrendsData = {
+      ...baseTrends,
+      surging: [],
+    };
+    renderTrends({ trends });
+    expect(screen.getByText("Surging Cards")).toBeInTheDocument();
+    expect(screen.queryByText("Night Stretcher")).not.toBeInTheDocument();
+    expect(screen.getByText("Nest Ball")).toBeInTheDocument();
+  });
+
+  it("renders empty tables when declining is empty but surging has data", () => {
+    const trends: TrendsData = {
+      ...baseTrends,
+      declining: [],
+    };
+    renderTrends({ trends });
+    expect(screen.getByText("Declining Cards")).toBeInTheDocument();
+    expect(screen.queryByText("Nest Ball")).not.toBeInTheDocument();
+    expect(screen.getByText("Night Stretcher")).toBeInTheDocument();
+  });
+
+  it("renders both sections empty when no trends exist", () => {
+    const trends: TrendsData = {
+      ...baseTrends,
+      surging: [],
+      declining: [],
+    };
+    renderTrends({ trends });
+    expect(screen.getByText("Surging Cards")).toBeInTheDocument();
+    expect(screen.getByText("Declining Cards")).toBeInTheDocument();
+    expect(screen.queryByText("Night Stretcher")).not.toBeInTheDocument();
+    expect(screen.queryByText("Nest Ball")).not.toBeInTheDocument();
+  });
+
+  it("renders the date filter", () => {
+    renderTrends();
+    expect(screen.getByTestId("date-filter")).toBeInTheDocument();
+  });
+
+  it("renders winning edge empty when no cards provided", () => {
+    renderTrends({ winningEdge: [] });
+    expect(screen.getByText(/Winning Edge/)).toBeInTheDocument();
+    expect(screen.queryByText("Prime Catcher")).not.toBeInTheDocument();
+  });
+});

--- a/web/app/lib/types.ts
+++ b/web/app/lib/types.ts
@@ -45,6 +45,7 @@ export interface BuylistCard {
   set_code: string | null;
   set_number: string | null;
   priority_score: number;
+  urgency: "URGENT" | "HIGH" | "MODERATE";
   core_flex: "core" | "flex";
   image_path?: string;
   archetypes: string[];

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7425,6 +7425,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

Comprehensive test coverage expansion identified via a council audit. Test count grows from **531 to 960** (+429 tests).

### Python: 422 → 772 (+350 tests)

| New File | Tests | Coverage Area |
|----------|-------|---------------|
| `test_buylist.py` | 30 | Priority scoring, urgency, rotation filter, energy exclusion, core/flex |
| `test_translation.py` | 28 | JP-to-EN lookup, `_translate_all_json`, alias normalization |
| `test_limitless_transforms.py` | 17 | Scraper HTML parsing (no HTTP mocks, string literals only) |
| `test_config.py` | 10 | Tier thresholds, placement weights, format dates, core thresholds |
| `test_archetype.py` | +4 | SPRITE_ARCHETYPE_MAP / composite filename consistency |
| `test_data_contracts.py` | +9 | Timeline, card-analysis, winning-edge, champions-league contracts |

### Frontend: 109 → 188 (+79 tests)

| New File | Tests | Coverage Area |
|----------|-------|---------------|
| `dashboard-client.test.tsx` | 9 | Tier sections, links, meta shares, stats |
| `buylist-client.test.tsx` | 19 | Cards, search, sort, tabs |
| `trends-client.test.tsx` | 17 | Surging/declining, winning edge, empty states |
| `archetypes-client.test.tsx` | 16 | Tier grouping, sprites, meta shares, tabs |
| `tournaments-client.test.tsx` | 15 | Table rendering, grouping, stats |

### Bug Fixes

- **`archetype.py`**: Added missing `porygon-z` entry in `SPRITE_ARCHETYPE_MAP` (caught by new consistency test)
- **`conftest.py`**: Fixed `rotation_legal` blind spot -- all cards defaulted to 0, so buylist's primary filter was never exercised
- **`test_data_contracts.py`**: Fixed buylist contract that silently passed on empty results (`if len > 0` → `assert len > 0`)
- **`types.ts`**: Added `urgency` field to `BuylistCard` (resolves Python/TypeScript drift)