### PR TITLE
fix: run schema migrations before export-web

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1167,6 +1167,7 @@ def export_web(ctx: click.Context, narrative: bool, strict: bool) -> None:
 
     fmt = ctx.obj["format"]
     conn = get_format_connection(fmt)
+    init_db(conn)
     # Open Labs connection for matchup cascade (auto-upgrades when data exists)
     labs_conn = None
     try:


### PR DESCRIPTION
## Summary
- The `export-web` CLI command opened a database connection without running `init_db()`, so older databases (like nihil-zero's `scout.db`) missing the `prefecture` column caused the city-league-index export to silently fail
- Added `init_db(conn)` call before exporting to ensure schema migrations run first
- This unblocks the nihil-zero tournaments page at scout.trainerlab.io/nihil-zero/tournaments (430 tournaments, 6,756 decks)

## Test plan
- [x] `python -m pytest tests/test_city_league_index_export.py -v` — 14 passed
- [x] `npm test` in `web/` — 331 passed
- [x] Verified `city-league-index.json` generated with 430 tournaments

🤖 Generated with [Claude Code](https://claude.com/claude-code)