### PR TITLE
feat: collapsible date groups in tournaments list

### DIFF
--- a/web/app/[format]/tournaments/__tests__/tournaments-client.test.tsx
+++ b/web/app/[format]/tournaments/__tests__/tournaments-client.test.tsx
@@ -245,6 +245,25 @@ describe("TournamentsClient", () => {
     expect(screen.getByText("Nagoya CL")).toBeInTheDocument();
   });
 
+  it("collapses an expanded date group on click", () => {
+    const tournaments = [
+      makeTournament({ id: "t-1", name: "Tokyo CL", date: "2026-03-20" }),
+      makeTournament({ id: "t-2", name: "Osaka CL", date: "2026-03-20" }),
+    ];
+    render(
+      <TournamentsClient
+        format="ninja-spinner"
+        index={makeIndex(tournaments)}
+        dateRange={defaultDateRange}
+      />,
+    );
+    // Latest group is expanded by default
+    expect(screen.getByText("Tokyo CL")).toBeInTheDocument();
+    // Click to collapse
+    fireEvent.click(screen.getByText("Mar 20, 2026"));
+    expect(screen.queryByText("Tokyo CL")).not.toBeInTheDocument();
+  });
+
   it("shows group tournament count label", () => {
     const tournaments = [
       makeTournament({ id: "t-1", name: "Tokyo CL", date: "2026-03-20" }),

--- a/web/app/[format]/tournaments/tournaments-client.tsx
+++ b/web/app/[format]/tournaments/tournaments-client.tsx
@@ -351,14 +351,14 @@ export function TournamentsClient({
     return new Set(groups.length > 0 ? [groups[0].date] : []);
   });
 
-  // Reset collapse state when date window changes
+  // Reset collapse state when displayed tournaments change
   useEffect(() => {
     if (dateGroups.length > 0) {
       setExpandedDates(new Set([dateGroups[0].date]));
     } else {
       setExpandedDates(new Set());
     }
-  }, [activeWindow, customRange]);
+  }, [dateGroups]);
 
   const toggleDateGroup = useCallback((date: string) => {
     setExpandedDates((prev) => {
@@ -491,9 +491,11 @@ export function TournamentsClient({
             return (
               <div key={group.date}>
                 {/* Date group header */}
-                <div
-                  className="sticky top-14 z-10 flex items-center gap-2 px-4 py-2 bg-surface-700/90 backdrop-blur-sm border-b border-surface-600 cursor-pointer select-none hover:bg-surface-700 transition-colors"
+                <button
+                  type="button"
+                  className="sticky top-14 z-10 flex items-center gap-2 px-4 py-2 w-full text-left bg-surface-700/90 backdrop-blur-sm border-b border-surface-600 cursor-pointer select-none hover:bg-surface-700 transition-colors"
                   onClick={() => toggleDateGroup(group.date)}
+                  aria-expanded={isExpanded}
                 >
                   <ChevronRight
                     className={cn(
@@ -510,7 +512,7 @@ export function TournamentsClient({
                       ? "tournament"
                       : "tournaments"}
                   </span>
-                </div>
+                </button>
 
                 {/* Tournament rows */}
                 {isExpanded &&


### PR DESCRIPTION
## Summary
- Date group headers in the tournaments list are now clickable toggles with a rotating chevron
- Latest date starts expanded, older dates collapsed -- much easier to scan 430+ tournaments
- Collapse state resets when switching date window filters (All Time, 30d, 7d, Custom)

## Test plan
- [x] All 349 frontend tests pass (15 tournaments-specific)
- [x] Updated grouping test to verify collapse/expand behavior
- [ ] Visual check on scout.trainerlab.io/nihil-zero/tournaments after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)